### PR TITLE
75 crypto hashing a literal reference uri node

### DIFF
--- a/src/FhirPseudonymizer.Tests/CryptoHashProcessorTests.cs
+++ b/src/FhirPseudonymizer.Tests/CryptoHashProcessorTests.cs
@@ -1,0 +1,40 @@
+using FakeItEasy;
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.FhirPath;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Anonymizer.Core.Extensions;
+using Microsoft.Health.Fhir.Anonymizer.Core.Processors;
+using Microsoft.Health.Fhir.Anonymizer.Core.Utility;
+using Xunit;
+
+namespace FhirPseudonymizer.Tests;
+
+public class CryptoHashProcessorTests
+{
+    public static IEnumerable<object[]> GetProcessData()
+    {
+
+            yield return new object[] { new FhirString("12345"),"098fe201710ca56e73dfb56cb0c610a66900add818c6d625b44b91eaafe79022" };
+            yield return new object[] { new ResourceReference("Patient/12345"),"Patient/098fe201710ca56e73dfb56cb0c610a66900add818c6d625b44b91eaafe79022" };
+            yield return new object[] { new FhirUri("Patient/12345"),"Patient/098fe201710ca56e73dfb56cb0c610a66900add818c6d625b44b91eaafe79022" };
+    }
+
+    [Theory]
+    [MemberData(nameof(GetProcessData))]
+    public void Process_HashesIdPart(DataType element, string expected)
+    {
+        var processor = new CryptoHashProcessor("test");
+
+        var node = ElementNode.FromElement(element.ToTypedElement());
+        while (!node.HasValue())
+        {
+            node = node.Children().CastElementNodes().First();
+        }
+
+        processor.Process(node);
+
+        node.Value.ToString().Should().Be(expected);
+
+    }
+}

--- a/src/FhirPseudonymizer/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Extensions/ElementNodeExtension.cs
+++ b/src/FhirPseudonymizer/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Extensions/ElementNodeExtension.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Hl7.Fhir.ElementModel;
+using Microsoft.Health.Fhir.Anonymizer.Core.Utility;
 
 namespace Microsoft.Health.Fhir.Anonymizer.Core.Extensions
 {
@@ -66,6 +67,20 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Extensions
                    node.Parent.IsReferenceNode() &&
                    string.Equals(node.Name, Constants.ReferenceStringNodeName,
                        StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public static bool IsReferenceUriNode(this ElementNode node, string value)
+        {
+            return node != null && string.Equals(node.InstanceType, "uri",
+                                    StringComparison.InvariantCultureIgnoreCase)
+                                && ReferenceUtility.IsResourceReference(value);
+        }
+
+        public static bool IsConditionalReferenceNode(this ElementNode node, string value)
+        {
+            return node != null && string.Equals(node.Name, "ifNoneExist",
+                                    StringComparison.InvariantCultureIgnoreCase)
+                                && ReferenceUtility.IsResourceReference(value);
         }
 
         public static bool IsEntryNode(this ElementNode node)

--- a/src/FhirPseudonymizer/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/CryptoHashProcessor.cs
+++ b/src/FhirPseudonymizer/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/CryptoHashProcessor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Processors
             }
 
             var input = node.Value.ToString();
-            // Hash the id part for "Reference.reference" node and hash whole input for other node types
+            // Hash the id part for "reference" and "uri" nodes and hash whole input for other node types
             if (node.IsReferenceStringNode() || node.IsReferenceUriNode(input))
             {
                 var newReference = ReferenceUtility.TransformReferenceId(input, _cryptoHashFunction);

--- a/src/FhirPseudonymizer/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/CryptoHashProcessor.cs
+++ b/src/FhirPseudonymizer/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/CryptoHashProcessor.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Processors
 
             var input = node.Value.ToString();
             // Hash the id part for "Reference.reference" node and hash whole input for other node types
-            if (node.IsReferenceStringNode())
+            if (node.IsReferenceStringNode() || node.IsReferenceUriNode(input))
             {
                 var newReference = ReferenceUtility.TransformReferenceId(input, _cryptoHashFunction);
                 node.Value = newReference;

--- a/src/FhirPseudonymizer/Pseudonymization/PseudonymizationProcessor.cs
+++ b/src/FhirPseudonymizer/Pseudonymization/PseudonymizationProcessor.cs
@@ -49,7 +49,7 @@ namespace FhirPseudonymizer.Pseudonymization
 
             // Pseudonymize the id part for "Reference.reference" node and
             // pseudonymize whole input for other node types
-            if (node.IsReferenceStringNode() || IsReferenceUriNode(node, input))
+            if (node.IsReferenceStringNode() || node.IsReferenceUriNode(input))
             {
                 // if the domain setting is not set,
                 // create a domain from the reference, ie "Patient/123" -> "Patient"
@@ -61,7 +61,7 @@ namespace FhirPseudonymizer.Pseudonymization
                     input,
                     x => GetOrCreatePseudonym(x, domainPrefix.ToString() + domain));
             }
-            else if (IsConditionalReferencePseudonymizationEnabled && IsConditionalElement(node, input))
+            else if (IsConditionalReferencePseudonymizationEnabled && node.IsConditionalReferenceNode(input))
             {
                 domain ??= ResourceTypeMatcher.Match(ReferenceUtility
                     .GetReferencePrefix(input)).Groups["domain"].Value;

--- a/src/FhirPseudonymizer/Pseudonymization/PseudonymizationProcessor.cs
+++ b/src/FhirPseudonymizer/Pseudonymization/PseudonymizationProcessor.cs
@@ -65,6 +65,10 @@ namespace FhirPseudonymizer.Pseudonymization
             {
                 domain ??= ResourceTypeMatcher.Match(ReferenceUtility
                     .GetReferencePrefix(input)).Groups["domain"].Value;
+
+                node.Value = ReferenceUtility.TransformReferenceId(
+                    input,
+                    x => GetOrCreatePseudonym(x, domainPrefix.ToString() + domain));
             }
             else
             {


### PR DESCRIPTION
This extends the special case when crypto hashing a [literal reference](https://www.hl7.org/fhir/references.html#literal) element by supporting [uri](https://build.fhir.org/datatypes.html#uri) nodes like `Bundle.entry.request.url` or `Bundle.entry.fullUrl` in addition to reference string nodes.