### PR TITLE
docs: updated scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FHIR® Pseudonymizer
 
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/miracum/fhir-pseudonymizer/badge)](https://api.securityscorecards.dev/projects/github.com/miracum/fhir-pseudonymizer)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/miracum/fhir-pseudonymizer/badge)](https://scorecard.dev/viewer/?uri=github.com/miracum/fhir-pseudonymizer)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 <p align="center"><img width="100" src="docs/img/logo.png" alt="FHIR® Pseudonymizer Logo"></p>


### PR DESCRIPTION
The new kind of badge points to a human readable viewer instead to an API endpoint.