### PR TITLE
feat: dynamic per-project anonymization config

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,56 @@ Accessing this endpoint requires authentication. So make sure to set the `APIKEY
 
 > ⚠ if decryption or de-pseudonymization of a value fails, then the original value is returned. This behavior may change or be made configurable in the future.
 
+#### `/projects` — per-project anonymization rules
+
+By default every request is de-identified with the single `anonymization.yaml` the server was started with. A **project** lets a caller register a second set of rules at runtime and select it per request, so one deployment can serve several studies without one config per instance.
+
+Register a config by `PUT`ting the YAML to `/projects/<name>`:
+
+```sh
+curl -X PUT "http://localhost:8080/projects/my-study" \
+  -H "x-api-key: ${APIKEY}" \
+  -H "Content-Type: application/yaml" \
+  --data-binary @my-study-anonymization.yaml
+```
+
+`201` means it was registered, `200` that it replaced an earlier config of the same name. `400` means the config is unusable — it is parsed and its engines are built during registration, so mistakes surface here rather than on the first resource. `503` means the registry is full (see `ProjectCache__SizeLimit` below); registration triggers a compaction, so retry shortly.
+
+Then select the project by wrapping the resource in a `Parameters` body carrying a `project` parameter, alongside the `resource` to de-identify:
+
+```sh
+curl -X POST "http://localhost:8080/fhir/\$de-identify" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+        "resourceType": "Parameters",
+        "parameter": [
+          { "name": "project", "valueString": "my-study" },
+          { "name": "resource", "resource": { "resourceType": "Patient", "id": "example" } }
+        ]
+      }'
+```
+
+Selection applies to `$de-identify` only. Send a bare resource, or a `Parameters` body without a `project`, and the server's own config is used, exactly as before — projects are purely additive. `$de-pseudonymize` is always served with the server's own config.
+
+A `project` parameter that is present but carries no usable name — a value that is not a `valueString`, an empty one, or a name outside the character set below — is answered with `400`, never served with the server's config. Selecting a project and silently getting different rules would be indistinguishable, in the response, from getting the ones you asked for.
+
+`DELETE /projects/<name>` releases a project. It is idempotent and always answers `204`.
+
+**A project is cached, not stored.** The registry is a bounded in-memory cache, held per replica and lost on restart. A request naming a project this replica does not know is answered with `404` and an `OperationOutcome` telling the caller to register it again — which is the expected way to recover after a restart, a scale-out to a fresh replica, or an eviction. **Clients must handle `404` by re-registering and retrying**, not by treating it as a fatal error. The `400` above is the opposite case and must not be retried: no registration could make an unusable name resolve.
+
+Reaching `ProjectCache__SizeLimit` evicts exactly one project to make room for the one being registered, so an overflow costs one other caller a re-registration rather than a share of the whole registry.
+
+Two consequences of that design:
+
+- **Projects do not apply to the Kafka consumer path**, which always uses the server's config. A consumer has no caller to return a `404` to and no client that could re-register, so a project-scoped message could never heal itself.
+- **A project's config must carry its own keys.** `encrypt` and `cryptoHash` rules need `parameters.encryptKey` / `parameters.cryptoHashKey` inside the project's own YAML; nothing is inherited from `Anonymization__EncryptKey` or the server's config. A config using one of those methods without its key is rejected with `400`. This is what keeps one project from decrypting another's data. (`$de-pseudonymize` is served only with the server's own config, so a project's ciphertext cannot be reversed through this API at all.)
+
+Registration and deletion require the `x-api-key` header whenever `ApiKey` is set. If `ApiKey` is empty, they are open — as is the rest of the API in that configuration.
+
+Project names are limited to letters, digits, `.`, `_` and `-`, up to 64 characters, and are matched case-sensitively. They appear in server logs, so avoid encoding cohort, site, or patient information in a project name.
+
+The server still requires an anonymization config of its own: projects are an addition to it, not a replacement, so a deployment that sets neither `AnonymizationEngineConfigPath` nor `AnonymizationEngineConfigInline` refuses to start.
+
 #### `:8081/metrics`
 
 While not part of the "user" API, the application exposes metrics in the Prometheus format at the `/metrics` endpoint on port `8081`.
@@ -119,6 +169,9 @@ Additionally, there are some optional configuration values that can be set as en
 | `Anonymization__CryptoHashKey`        | Sets the key used by the HMAC SHA256 algorithm. This is an alternative to setting it inside the anonymization.yaml's `parameters` section and useful to more securely set sensitive information.                         | `""`                        |
 | `Anonymization__EncryptKey`           | Sets the AES encryption key. This is an alternative to setting it inside the anonymization.yaml's `parameters` section and useful to more securely set sensitive information.                                            | `""`                        |
 | `Anonymization__ShouldAddSecurityTag` | Whether the `Resource.meta.security` element should be filled with information about the de-identification methods applied to the resource.                                                                              | `true`                      |
+| `ProjectCache__SizeLimit`             | How many [projects](#projects--per-project-anonymization-rules) may be registered at once. Registration beyond this answers `503`. Bounds the memory an unauthenticated caller can claim, so it is not optional.         | `128`                       |
+| `ProjectCache__SlidingExpirationMinutes` | Drop a project this many minutes after it was last used. `0` disables expiry, which is the default: a project should stay usable for as long as it fits.                                                              | `0`                         |
+| `ProjectCache__AbsoluteExpirationMinutes` | Drop a project this many minutes after it was registered, used or not. `0` disables expiry.                                                                                                                          | `0`                         |
 
 See [appsettings.json](src/FhirPseudonymizer/appsettings.json) for additional options.
 

--- a/src/FhirPseudonymizer.Tests/FhirControllerFuzzTests.cs
+++ b/src/FhirPseudonymizer.Tests/FhirControllerFuzzTests.cs
@@ -1,6 +1,7 @@
 using FhirPseudonymizer.Config;
 using FhirPseudonymizer.Controllers;
 using FhirPseudonymizer.Kafka;
+using FhirPseudonymizer.Projects;
 using FsCheck;
 using FsCheck.Xunit;
 using Hl7.Fhir.Model;
@@ -25,9 +26,9 @@ public class FhirControllerFuzzTests
         new(
             A.Fake<AnonymizationConfig>(),
             A.Fake<ILogger<FhirController>>(),
-            anonymizer,
-            A.Fake<IDePseudonymizerEngine>(),
-            A.Fake<IProvenancePublisher>()
+            new ProjectEngines(anonymizer, A.Fake<IDePseudonymizerEngine>()),
+            A.Fake<IProvenancePublisher>(),
+            A.Fake<IProjectRegistry>()
         );
 
     private static Parameters BuildRequest(IEnumerable<Tuple<string, Base>> settingsParts) =>

--- a/src/FhirPseudonymizer.Tests/FhirControllerTests.cs
+++ b/src/FhirPseudonymizer.Tests/FhirControllerTests.cs
@@ -1,8 +1,8 @@
 using FhirPseudonymizer.Config;
 using FhirPseudonymizer.Controllers;
 using FhirPseudonymizer.Kafka;
+using FhirPseudonymizer.Projects;
 using Hl7.Fhir.Model;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Anonymizer.Core;
 using Microsoft.Health.Fhir.Anonymizer.Core.AnonymizerConfigurations;
@@ -11,6 +11,14 @@ namespace FhirPseudonymizer.Tests;
 
 public class FhirControllerTests
 {
+    private static ProjectEngines ServerEnginesOf(
+        IAnonymizerEngine anonymizer,
+        IDePseudonymizerEngine dePseudonymizer
+    )
+    {
+        return new ProjectEngines(anonymizer, dePseudonymizer);
+    }
+
     [Fact]
     public async Task DeIdentify_ParsesDynamicSettings()
     {
@@ -26,9 +34,9 @@ public class FhirControllerTests
         var controller = new FhirController(
             A.Fake<AnonymizationConfig>(),
             A.Fake<ILogger<FhirController>>(),
-            anonymizer,
-            A.Fake<IDePseudonymizerEngine>(),
-            A.Fake<IProvenancePublisher>()
+            ServerEnginesOf(anonymizer, A.Fake<IDePseudonymizerEngine>()),
+            A.Fake<IProvenancePublisher>(),
+            A.Fake<IProjectRegistry>()
         );
 
         var parameters = new Parameters()
@@ -55,9 +63,9 @@ public class FhirControllerTests
         var controller = new FhirController(
             A.Fake<AnonymizationConfig>(),
             A.Fake<ILogger<FhirController>>(),
-            anonymizer,
-            A.Fake<IDePseudonymizerEngine>(),
-            A.Fake<IProvenancePublisher>()
+            ServerEnginesOf(anonymizer, A.Fake<IDePseudonymizerEngine>()),
+            A.Fake<IProvenancePublisher>(),
+            A.Fake<IProjectRegistry>()
         );
 
         var parameters = new Parameters()
@@ -67,6 +75,78 @@ public class FhirControllerTests
         await controller.DeIdentify(parameters);
 
         ruleSettings.Should().ContainKey(settingKey).WhoseValue.Should().Be(settingValue);
+    }
+
+    /// <summary>
+    ///     A name the registration endpoint would reject cannot name a registered Project, so
+    ///     <c>$de-identify</c> refuses it outright. That keeps it out of the log and out of the
+    ///     response, which is what bounds both: nothing but the body size limit bounds the name a
+    ///     Parameters body carries.
+    /// </summary>
+    [Theory]
+    [InlineData("innocent\nERROR: forged log entry", "a line break would forge a second log entry")]
+    [InlineData("has a space", "a space is outside the allowed set")]
+    public async Task DeIdentify_WithAnUnusableProjectName_ShouldRejectItWithoutRepeatingIt(
+        string projectName,
+        string because
+    )
+    {
+        var logger = new RecordingLogger<FhirController>();
+        var controller = ControllerWith(logger);
+
+        var parameters = new Parameters()
+            .Add("project", new FhirString(projectName))
+            .Add("resource", new Patient());
+
+        var response = await controller.DeIdentify(parameters);
+
+        response.StatusCode.Should().Be(400, because);
+        logger.Messages.Should().OnlyContain(message => !message.Contains('\n'));
+        response
+            .Value.Should()
+            .BeOfType<OperationOutcome>()
+            .Which.Issue.Should()
+            .ContainSingle()
+            .Which.Diagnostics.Should()
+            .NotContain(projectName, "a rejected name is the caller's, not something to echo");
+    }
+
+    [Fact]
+    public async Task DeIdentify_WithAFloodingProjectName_ShouldNotFloodTheLogOrTheResponse()
+    {
+        var logger = new RecordingLogger<FhirController>();
+        var controller = ControllerWith(logger);
+
+        var parameters = new Parameters()
+            .Add("project", new FhirString(new string('a', 10_000)))
+            .Add("resource", new Patient());
+
+        var response = await controller.DeIdentify(parameters);
+
+        response.StatusCode.Should().Be(400, "10 000 characters is past the 64 a name may hold");
+        logger.Messages.Should().OnlyContain(message => message.Length < 200);
+        response
+            .Value.Should()
+            .BeOfType<OperationOutcome>()
+            .Which.Issue.Should()
+            .ContainSingle()
+            .Which.Diagnostics.Length.Should()
+            .BeLessThan(500, "a caller must not be able to size the response from the body");
+    }
+
+    /// <summary>
+    ///     A Project-less controller: its registry holds nothing, so any name reaching it is
+    ///     unknown.
+    /// </summary>
+    private static FhirController ControllerWith(RecordingLogger<FhirController> logger)
+    {
+        return new FhirController(
+            A.Fake<AnonymizationConfig>(),
+            logger,
+            ServerEnginesOf(A.Fake<IAnonymizerEngine>(), A.Fake<IDePseudonymizerEngine>()),
+            A.Fake<IProvenancePublisher>(),
+            A.Fake<IProjectRegistry>()
+        );
     }
 
     [Fact]
@@ -79,9 +159,9 @@ public class FhirControllerTests
         var controller = new FhirController(
             A.Fake<AnonymizationConfig>(),
             A.Fake<ILogger<FhirController>>(),
-            anonymizer,
-            A.Fake<IDePseudonymizerEngine>(),
-            A.Fake<IProvenancePublisher>()
+            ServerEnginesOf(anonymizer, A.Fake<IDePseudonymizerEngine>()),
+            A.Fake<IProvenancePublisher>(),
+            A.Fake<IProjectRegistry>()
         );
 
         var response = await controller.DeIdentify(new Bundle());
@@ -97,9 +177,9 @@ public class FhirControllerTests
         var controller = new FhirController(
             A.Fake<AnonymizationConfig>(),
             A.Fake<ILogger<FhirController>>(),
-            A.Fake<IAnonymizerEngine>(),
-            A.Fake<IDePseudonymizerEngine>(),
-            A.Fake<IProvenancePublisher>()
+            ServerEnginesOf(A.Fake<IAnonymizerEngine>(), A.Fake<IDePseudonymizerEngine>()),
+            A.Fake<IProvenancePublisher>(),
+            A.Fake<IProjectRegistry>()
         );
 
         var response = await controller.DeIdentify(new Parameters());
@@ -123,9 +203,9 @@ public class FhirControllerTests
         var controller = new FhirController(
             A.Fake<AnonymizationConfig>(),
             A.Fake<ILogger<FhirController>>(),
-            anonymizer,
-            A.Fake<IDePseudonymizerEngine>(),
-            provenancePublisher
+            ServerEnginesOf(anonymizer, A.Fake<IDePseudonymizerEngine>()),
+            provenancePublisher,
+            A.Fake<IProjectRegistry>()
         );
 
         await controller.DeIdentify(original);
@@ -148,9 +228,9 @@ public class FhirControllerTests
         var controller = new FhirController(
             A.Fake<AnonymizationConfig>(),
             A.Fake<ILogger<FhirController>>(),
-            A.Fake<IAnonymizerEngine>(),
-            dePseudonymizer,
-            provenancePublisher
+            ServerEnginesOf(A.Fake<IAnonymizerEngine>(), dePseudonymizer),
+            provenancePublisher,
+            A.Fake<IProjectRegistry>()
         );
 
         await controller.DePseudonymize(new Patient { Id = "123" });
@@ -177,9 +257,9 @@ public class FhirControllerTests
         var controller = new FhirController(
             A.Fake<AnonymizationConfig>(),
             A.Fake<ILogger<FhirController>>(),
-            A.Fake<IAnonymizerEngine>(),
-            dePseudonymizer,
-            A.Fake<IProvenancePublisher>()
+            ServerEnginesOf(A.Fake<IAnonymizerEngine>(), dePseudonymizer),
+            A.Fake<IProvenancePublisher>(),
+            A.Fake<IProjectRegistry>()
         );
 
         var response = await controller.DePseudonymize(new Bundle());

--- a/src/FhirPseudonymizer.Tests/ProjectRegistryTests.cs
+++ b/src/FhirPseudonymizer.Tests/ProjectRegistryTests.cs
@@ -1,0 +1,141 @@
+using FhirPseudonymizer.Config;
+using FhirPseudonymizer.Projects;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Health.Fhir.Anonymizer.Core;
+using Microsoft.Health.Fhir.Anonymizer.Core.AnonymizerConfigurations;
+
+namespace FhirPseudonymizer.Tests;
+
+public class ProjectRegistryTests
+{
+    private const string SomeValidConfig = """
+        fhirVersion: R4
+        fhirPathRules:
+          - path: Patient.id
+            method: keep
+        """;
+
+    [Fact]
+    public void Ctor_WithASizeLimitOfZero_ShouldFailFastNamingTheSetting()
+    {
+        var create = () =>
+            new ProjectRegistry(
+                A.Fake<IAnonymizerEngineFactory>(),
+                new CacheConfig { SizeLimit = 0 }
+            );
+
+        create
+            .Should()
+            .Throw<InvalidOperationException>(
+                "a zero-sized registry rejects every entry, turning each registration into "
+                    + "a 503 that promises a retry which can never succeed"
+            )
+            .WithMessage("*ProjectCache:SizeLimit*");
+    }
+
+    [Fact]
+    public void Register_AgainstAConfigurationNamingNoProjectCache_ShouldStoreTheProject()
+    {
+        // The shipped appsettings.json carries a limit, but nothing guarantees a deployment
+        // layers that file — so the limit has to survive binding against a configuration that
+        // says nothing about it, rather than falling to a zero that stores nothing.
+        var appConfig = new AppConfig();
+        new ConfigurationBuilder().Build().Bind(appConfig);
+
+        using var registry = new ProjectRegistry(
+            A.Fake<IAnonymizerEngineFactory>(),
+            appConfig.ProjectCache
+        );
+
+        registry
+            .Register("some-project", SomeValidConfig)
+            .Should()
+            .Be(ProjectRegistrationOutcome.Created);
+    }
+
+    [Fact]
+    public async Task Register_AtAFullSmallRegistry_ShouldFreeASlotSoARetrySucceeds()
+    {
+        using var registry = new ProjectRegistry(
+            A.Fake<IAnonymizerEngineFactory>(),
+            new CacheConfig { SizeLimit = 2 }
+        );
+        registry.Register("first", SomeValidConfig).Should().Be(ProjectRegistrationOutcome.Created);
+        registry
+            .Register("second", SomeValidConfig)
+            .Should()
+            .Be(ProjectRegistrationOutcome.Created);
+
+        var outcome = registry.Register("third", SomeValidConfig);
+
+        outcome
+            .Should()
+            .Be(ProjectRegistrationOutcome.NotStored, "the registry was full at that moment");
+
+        // The rejection's 503 promises that a retry will succeed shortly, because reaching the
+        // limit triggers a compaction. It runs on a background thread, hence the polling.
+        for (var i = 0; i < 100 && outcome == ProjectRegistrationOutcome.NotStored; i++)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+            outcome = registry.Register("third", SomeValidConfig);
+        }
+
+        outcome.Should().Be(ProjectRegistrationOutcome.Created);
+    }
+
+    [Fact]
+    public async Task Register_AtAFullRegistry_ShouldCostExactlyOneOtherProject()
+    {
+        // Every evicted Project is a caller whose next request 404s and who has to register
+        // again, so how many an overflow costs is not academic. 40 tells the candidate rates
+        // apart: a flat 5% frees two entries, one slot's worth frees one.
+        const int sizeLimit = 40;
+        using var registry = new ProjectRegistry(
+            EngineFactory(),
+            new CacheConfig { SizeLimit = sizeLimit }
+        );
+        for (var i = 0; i < sizeLimit; i++)
+        {
+            registry
+                .Register($"project-{i}", SomeValidConfig)
+                .Should()
+                .Be(ProjectRegistrationOutcome.Created);
+        }
+
+        registry
+            .Register("one-too-many", SomeValidConfig)
+            .Should()
+            .Be(ProjectRegistrationOutcome.NotStored, "the registry was full at that moment");
+
+        // Registered exactly once: each rejection schedules its own compaction, so retrying here
+        // would evict again and measure something else. The compaction runs on a background
+        // thread, hence the polling.
+        var survivors = sizeLimit;
+        for (var i = 0; i < 100 && survivors == sizeLimit; i++)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+            survivors = Enumerable
+                .Range(0, sizeLimit)
+                .Count(j => registry.TryGet($"project-{j}", out _));
+        }
+
+        survivors
+            .Should()
+            .Be(sizeLimit - 1, "making room for one Project should cost exactly one other");
+    }
+
+    /// <summary>
+    ///     Returns real (if empty) Engines rather than the null a bare fake would, so a lookup
+    ///     answers on the entry's presence instead of on how a cache treats a null value.
+    /// </summary>
+    private static IAnonymizerEngineFactory EngineFactory()
+    {
+        var factory = A.Fake<IAnonymizerEngineFactory>();
+        A.CallTo(() => factory.Create(A<AnonymizerConfigurationManager>._))
+            .ReturnsLazily(() =>
+                new ProjectEngines(A.Fake<IAnonymizerEngine>(), A.Fake<IDePseudonymizerEngine>())
+            );
+
+        return factory;
+    }
+}

--- a/src/FhirPseudonymizer.Tests/ProjectsControllerTests.cs
+++ b/src/FhirPseudonymizer.Tests/ProjectsControllerTests.cs
@@ -1,0 +1,36 @@
+using FhirPseudonymizer.Controllers;
+using FhirPseudonymizer.Projects;
+
+namespace FhirPseudonymizer.Tests;
+
+public class ProjectsControllerTests
+{
+    [Fact]
+    public async Task Register_WithANameCarryingALineBreak_ShouldLogItOnASingleLine()
+    {
+        // A name is logged before anything has vetted it, so a caller could otherwise forge a
+        // second log entry by putting %0A in the route.
+        var logger = new RecordingLogger<ProjectsController>();
+        var controller = new ProjectsController(A.Fake<IProjectRegistry>(), logger);
+
+        await controller.Register("innocent\nERROR: forged log entry");
+
+        logger.Messages.Should().ContainSingle().Which.Should().NotContainAny("\n", "\r");
+    }
+
+    [Fact]
+    public async Task Register_WithAFloodingName_ShouldLogATruncatedName()
+    {
+        // Nothing bounds the name before the length check rejects it, so logging it whole hands
+        // a caller a way to push the whole route into one log line.
+        var logger = new RecordingLogger<ProjectsController>();
+        var controller = new ProjectsController(A.Fake<IProjectRegistry>(), logger);
+
+        await controller.Register(new string('a', 10_000));
+
+        var message = logger.Messages.Should().ContainSingle().Subject;
+        message
+            .Length.Should()
+            .BeLessThan(200, "a rejected name belongs in the log only far enough to recognise it");
+    }
+}

--- a/src/FhirPseudonymizer.Tests/ProjectsTests.cs
+++ b/src/FhirPseudonymizer.Tests/ProjectsTests.cs
@@ -1,0 +1,508 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+
+namespace FhirPseudonymizer.Tests;
+
+public class ProjectsTests(CustomWebApplicationFactory<Startup> factory)
+    : IClassFixture<CustomWebApplicationFactory<Startup>>
+{
+    /// <summary>
+    ///     Redacts what the startup config encrypts, so applying it is observable in the response.
+    /// </summary>
+    private const string RedactMedicalRecordNumberConfig = """
+        fhirVersion: R4
+        fhirPathRules:
+          - path: nodesByType('Identifier').value
+            method: redact
+        """;
+
+    /// <summary>
+    ///     The startup config encrypts this identifier's value; a redacting Project blanks it.
+    /// </summary>
+    private const string PatientWithMedicalRecordNumber = """
+        {
+            "resourceType": "Patient",
+            "id": "glossy",
+            "identifier": [
+                {
+                    "use": "usual",
+                    "type": {
+                        "coding": [
+                            {
+                                "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                "code": "MR"
+                            }
+                        ]
+                    },
+                    "system": "http://www.goodhealth.org/identifiers/mrn",
+                    "value": "123456"
+                }
+            ]
+        }
+        """;
+
+    /// <summary>
+    ///     Observably different from <see cref="RedactMedicalRecordNumberConfig" />: it leaves the
+    ///     identifier value untouched instead of blanking it.
+    /// </summary>
+    private const string KeepMedicalRecordNumberConfig = """
+        fhirVersion: R4
+        fhirPathRules:
+          - path: nodesByType('Identifier').value
+            method: keep
+        """;
+
+    private readonly HttpClient client = factory.CreateClient();
+
+    [Fact]
+    public async Task PutProject_WithValidConfig_ShouldReturnCreated()
+    {
+        var response = await RegisterProject("slice2-demo", RedactMedicalRecordNumberConfig);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task PostDeIdentify_WithRegisteredProjectName_ShouldApplyThatProjectsRules()
+    {
+        await RegisterProject("slice3-redact", RedactMedicalRecordNumberConfig);
+
+        var response = await DeIdentify(PatientWithMedicalRecordNumber, "slice3-redact");
+
+        response.EnsureSuccessStatusCode();
+        var patient = await ParsePatient(response);
+        patient.Identifier[0].Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PostDeIdentify_WithUnregisteredProjectName_ShouldReturnNotFoundOutcome()
+    {
+        var response = await DeIdentify(PatientWithMedicalRecordNumber, "slice4-never-registered");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var outcome = await ParseResource<OperationOutcome>(response);
+        outcome
+            .Issue.Should()
+            .ContainSingle()
+            .Which.Diagnostics.Should()
+            .Contain("slice4-never-registered");
+    }
+
+    [Theory]
+    [InlineData("", "empty")]
+    [InlineData("fhirPathRules: [unclosed", "malformed-yaml")]
+    [InlineData("fhirVersion: R4", "no-rules")]
+    [InlineData(
+        "fhirVersion: R4\nfhirPathRules:\n  - path: Patient.id\n    method: nonsense",
+        "unknown-method"
+    )]
+    [InlineData("fhirVersion: R4\nfhirPathRules: [null]", "null-rule")]
+    [InlineData(
+        "fhirVersion: R4\nfhirPathRules:\n  - path: Patient.id\n    method: redact\n  -",
+        "trailing-bare-dash"
+    )]
+    public async Task PutProject_WithConfigThatCannotBuildEngines_ShouldReturnBadRequestOutcome(
+        string yamlConfig,
+        string caseName
+    )
+    {
+        var response = await RegisterProject($"slice6-{caseName}", yamlConfig);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var outcome = await ParseResource<OperationOutcome>(response);
+        outcome
+            .Issue.Should()
+            .ContainSingle()
+            .Which.Severity.Should()
+            .Be(OperationOutcome.IssueSeverity.Error);
+    }
+
+    [Theory]
+    [InlineData("encrypt", "encryptKey")]
+    [InlineData("cryptoHash", "cryptoHashKey")]
+    [InlineData("dateShift", "dateShiftKey")]
+    public async Task PutProject_WithRuleWhoseKeyTheConfigDoesNotCarry_ShouldReturnBadRequestOutcome(
+        string method,
+        string missingParameter
+    )
+    {
+        var yamlConfig = $"""
+            fhirVersion: R4
+            fhirPathRules:
+              - path: nodesByType('Identifier').value
+                method: {method}
+            """;
+
+        var response = await RegisterProject($"slice7-{method}", yamlConfig);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var outcome = await ParseResource<OperationOutcome>(response);
+        outcome.Issue.Should().ContainSingle().Which.Diagnostics.Should().Contain(missingParameter);
+    }
+
+    /// <summary>
+    ///     Serving any of these with the server's own config would answer 200 to a caller who
+    ///     asked for a Project's rules, who would never learn that different ones ran.
+    /// </summary>
+    [Theory]
+    [InlineData("code", "a valueCode is not the valueString the parameter is read as")]
+    [InlineData("uri", "a valueUri is not the valueString the parameter is read as")]
+    [InlineData("empty-string", "an empty name selects nothing")]
+    [InlineData("unregistrable", "a name registration would reject can never resolve")]
+    public async Task PostDeIdentify_WithAProjectParameterCarryingNoUsableName_ShouldReturnBadRequestOutcome(
+        string shape,
+        string because
+    )
+    {
+        DataType projectValue = shape switch
+        {
+            "code" => new Code("slice13-code"),
+            "uri" => new FhirUri("slice13-uri"),
+            "empty-string" => new FhirString(""),
+            "unregistrable" => new FhirString("slice13 has a space"),
+            _ => null,
+        };
+
+        var response = await DeIdentify(PatientWithMedicalRecordNumber, projectValue);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, because);
+
+        var outcome = await ParseResource<OperationOutcome>(response);
+        outcome
+            .Issue.Should()
+            .ContainSingle()
+            .Which.Severity.Should()
+            .Be(OperationOutcome.IssueSeverity.Error);
+    }
+
+    [Fact]
+    public async Task PostDeIdentify_WithAValuelessProjectParameter_ShouldReturnBadRequestOutcome()
+    {
+        // Sent as raw JSON on purpose: Parameters.Add drops a null value instead of adding the
+        // component, so only the wire form can carry a 'project' that names nothing.
+        using var content = new StringContent(
+            """
+            {
+                "resourceType": "Parameters",
+                "parameter": [
+                    { "name": "project" },
+                    { "name": "resource", "resource": { "resourceType": "Patient" } }
+                ]
+            }
+            """
+        );
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/fhir+json");
+
+        var response = await client.PostAsync(
+            "/fhir/$de-identify",
+            content,
+            TestContext.Current.CancellationToken
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PostDeIdentify_WithMoreThanOneProjectParameter_ShouldReturnBadRequestOutcome()
+    {
+        // Not the 404's re-register-and-retry: no registration could tell the server which of
+        // the two names the caller meant, so only a corrected request can resolve this.
+        var resource = await new FhirJsonParser().ParseAsync<Resource>(
+            PatientWithMedicalRecordNumber
+        );
+        var parameters = new Parameters()
+            .Add("project", new FhirString("slice14-first"))
+            .Add("project", new FhirString("slice14-second"))
+            .Add("resource", resource);
+
+        using var content = new StringContent(await parameters.ToJsonAsync());
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/fhir+json");
+
+        var response = await client.PostAsync(
+            "/fhir/$de-identify",
+            content,
+            TestContext.Current.CancellationToken
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var outcome = await ParseResource<OperationOutcome>(response);
+        outcome
+            .Issue.Should()
+            .ContainSingle()
+            .Which.Severity.Should()
+            .Be(OperationOutcome.IssueSeverity.Error);
+    }
+
+    [Fact]
+    public async Task PostDeIdentify_WithParametersNamingNoProject_ShouldApplyTheServersOwnConfig()
+    {
+        // The promise that Projects are purely additive: the selector is optional, and a body
+        // that leaves it out has to come back exactly as it did before Projects existed.
+        var parameters = new Parameters().Add(
+            "resource",
+            await new FhirJsonParser().ParseAsync<Resource>(PatientWithMedicalRecordNumber)
+        );
+
+        using var content = new StringContent(await parameters.ToJsonAsync());
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/fhir+json");
+
+        var response = await client.PostAsync(
+            "/fhir/$de-identify",
+            content,
+            TestContext.Current.CancellationToken
+        );
+
+        response.EnsureSuccessStatusCode();
+        var value = (await ParsePatient(response)).Identifier[0].Value;
+        value
+            .Should()
+            .NotBeNull("the server's config encrypts the identifier rather than redacting it")
+            .And.NotBe("123456", "and it does not keep it either");
+    }
+
+    [Fact]
+    public async Task DeleteProject_ShouldMakeTheProjectUnknownAgain()
+    {
+        await RegisterProject("slice8-delete", RedactMedicalRecordNumberConfig);
+
+        var deleteResponse = await DeleteProject("slice8-delete");
+
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var deIdentifyResponse = await DeIdentify(PatientWithMedicalRecordNumber, "slice8-delete");
+        deIdentifyResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task PutProject_OverAnExistingProject_ShouldReturnOkAndServeTheNewConfig()
+    {
+        var firstResponse = await RegisterProject(
+            "slice9-overwrite",
+            RedactMedicalRecordNumberConfig
+        );
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var secondResponse = await RegisterProject(
+            "slice9-overwrite",
+            KeepMedicalRecordNumberConfig
+        );
+
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var patient = await ParsePatient(
+            await DeIdentify(PatientWithMedicalRecordNumber, "slice9-overwrite")
+        );
+        patient.Identifier[0].Value.Should().Be("123456");
+    }
+
+    [Theory]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    public async Task ProjectRegistration_WithApiKeyConfiguredButNotSupplied_ShouldReturnUnauthorized(
+        string method
+    )
+    {
+        using var request = new HttpRequestMessage(
+            new HttpMethod(method),
+            "/projects/slice11-unauthorized"
+        )
+        {
+            Content = new StringContent(RedactMedicalRecordNumberConfig),
+        };
+        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/yaml");
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task PutProject_WithBlankApiKey_ShouldBeAllowedWithoutCredentials()
+    {
+        using var openFactory = new CustomWebApplicationFactory<Startup>
+        {
+            CustomInMemorySettings = new Dictionary<string, string>
+            {
+                ["ApiKey"] = "",
+                ["EnableMetrics"] = "false",
+            },
+        };
+
+        using var content = new StringContent(RedactMedicalRecordNumberConfig);
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/yaml");
+
+        var response = await openFactory
+            .CreateClient()
+            .PutAsync("/projects/slice11-open", content, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task PutProject_WhenTheRegistryIsFull_ShouldReturnServiceUnavailableOutcome()
+    {
+        using var boundedFactory = new CustomWebApplicationFactory<Startup>
+        {
+            CustomInMemorySettings = new Dictionary<string, string>
+            {
+                ["ProjectCache:SizeLimit"] = "1",
+                ["EnableMetrics"] = "false",
+            },
+        };
+        var boundedClient = boundedFactory.CreateClient();
+
+        var first = await RegisterProject(
+            "slice12-first",
+            RedactMedicalRecordNumberConfig,
+            boundedClient
+        );
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var second = await RegisterProject(
+            "slice12-second",
+            RedactMedicalRecordNumberConfig,
+            boundedClient
+        );
+
+        second.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
+        var outcome = await ParseResource<OperationOutcome>(second);
+        outcome.Issue.Should().ContainSingle().Which.Diagnostics.Should().Contain("retry");
+    }
+
+    [Fact]
+    public void Startup_WithAZeroSizedProjectRegistry_ShouldFailFastNamingTheSetting()
+    {
+        using var factory = new CustomWebApplicationFactory<Startup>
+        {
+            CustomInMemorySettings = new Dictionary<string, string>
+            {
+                ["ProjectCache:SizeLimit"] = "0",
+                ["EnableMetrics"] = "false",
+            },
+        };
+
+        var start = () => factory.CreateClient();
+
+        start
+            .Should()
+            .Throw<InvalidOperationException>(
+                "a zero-sized registry answers every registration with a 503 promising a retry "
+                    + "that can never succeed, and it fails $de-identify too, so an operator has "
+                    + "to learn about it at boot rather than from the first request"
+            )
+            .WithMessage("*ProjectCache:SizeLimit*");
+    }
+
+    /// <summary>
+    ///     65 'a's - one past the limit.
+    /// </summary>
+    private const string TooLongProjectName =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [Theory]
+    [InlineData("forges%23sha256-deadbeef", "an encoded '#' is not in the allowed set")]
+    [InlineData("has%20a%20space", "spaces")]
+    [InlineData("pröject", "non-ascii")]
+    [InlineData(TooLongProjectName, "65 characters")]
+    [InlineData(
+        "trailing-newline%0A",
+        "a '$' anchor matches before a trailing newline, which '\\z' rejects"
+    )]
+    public async Task PutProject_WithANameOutsideTheAllowedCharacterSet_ShouldReturnBadRequestOutcome(
+        string name,
+        string because
+    )
+    {
+        var response = await RegisterProject(name, RedactMedicalRecordNumberConfig);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, because);
+
+        var outcome = await ParseResource<OperationOutcome>(response);
+        outcome
+            .Issue.Should()
+            .ContainSingle()
+            .Which.Severity.Should()
+            .Be(OperationOutcome.IssueSeverity.Error);
+    }
+
+    private async Task<HttpResponseMessage> DeleteProject(string name)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Delete, $"/projects/{name}");
+        request.Headers.Add("x-api-key", "dev");
+
+        return await client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private async Task<T> ParseResource<T>(HttpResponseMessage response)
+        where T : Resource
+    {
+        var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        return await new FhirJsonParser().ParseAsync<T>(json);
+    }
+
+    private async Task<Patient> ParsePatient(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        return await new FhirJsonParser().ParseAsync<Patient>(json);
+    }
+
+    /// <summary>
+    ///     Selects a Project by wrapping the resource in a Parameters body carrying a 'project'
+    ///     parameter — the request-body successor to the old <c>X-Project-Name</c> header.
+    /// </summary>
+    private async Task<HttpResponseMessage> DeIdentify(
+        string resourceJson,
+        string projectName,
+        HttpClient httpClient = null
+    )
+    {
+        return await DeIdentify(resourceJson, new FhirString(projectName), httpClient);
+    }
+
+    private async Task<HttpResponseMessage> DeIdentify(
+        string resourceJson,
+        DataType projectValue,
+        HttpClient httpClient = null
+    )
+    {
+        var resource = await new FhirJsonParser().ParseAsync<Resource>(resourceJson);
+        var parameters = new Parameters().Add("project", projectValue).Add("resource", resource);
+
+        using var content = new StringContent(await parameters.ToJsonAsync());
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/fhir+json");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/fhir/$de-identify")
+        {
+            Content = content,
+        };
+
+        return await (httpClient ?? client).SendAsync(
+            request,
+            TestContext.Current.CancellationToken
+        );
+    }
+
+    private async Task<HttpResponseMessage> RegisterProject(
+        string name,
+        string yamlConfig,
+        HttpClient httpClient = null
+    )
+    {
+        using var content = new StringContent(yamlConfig);
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/yaml");
+        content.Headers.Add("x-api-key", "dev");
+
+        return await (httpClient ?? client).PutAsync(
+            $"/projects/{name}",
+            content,
+            TestContext.Current.CancellationToken
+        );
+    }
+}

--- a/src/FhirPseudonymizer.Tests/RecordingLogger.cs
+++ b/src/FhirPseudonymizer.Tests/RecordingLogger.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Logging;
+
+namespace FhirPseudonymizer.Tests;
+
+/// <summary>
+///     Records what a component writes to the log, rendered the way a provider would render it.
+///     A fake cannot answer that question: the message only exists once the formatter has run
+///     over the state, which is exactly where an injected line break would show up.
+/// </summary>
+internal sealed class RecordingLogger<T> : ILogger<T>
+{
+    public List<string> Messages { get; } = [];
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception exception,
+        Func<TState, Exception, string> formatter
+    )
+    {
+        Messages.Add(formatter(state, exception));
+    }
+}

--- a/src/FhirPseudonymizer.Tests/StartupTests.cs
+++ b/src/FhirPseudonymizer.Tests/StartupTests.cs
@@ -1,0 +1,35 @@
+namespace FhirPseudonymizer.Tests;
+
+public class StartupTests
+{
+    /// <summary>
+    ///     Every request is served with the server's own config unless it names a Project, so a
+    ///     deployment holding no config has no rules to fall back on. Refusing at startup keeps
+    ///     that from surfacing as a failure on the first resource, long after the deploy.
+    /// </summary>
+    [Fact]
+    public void Startup_WithoutAnyAnonymizationConfig_ShouldFailFast()
+    {
+        using var factory = new CustomWebApplicationFactory<Startup>
+        {
+            CustomInMemorySettings = new Dictionary<string, string>
+            {
+                ["AnonymizationEngineConfigPath"] = "",
+                ["AnonymizationEngineConfigInline"] = "",
+                // a per-test factory would otherwise race the shared one for the metrics port
+                ["EnableMetrics"] = "false",
+            },
+        };
+
+        var start = () => factory.CreateClient();
+
+        start
+            .Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage(
+                "*Anonymization config not set*",
+                "an operator has to be told which setting to fix, not handed a dependency "
+                    + "resolution error"
+            );
+    }
+}

--- a/src/FhirPseudonymizer/AnonymizerEngineExtensions.cs
+++ b/src/FhirPseudonymizer/AnonymizerEngineExtensions.cs
@@ -1,5 +1,5 @@
 using FhirPseudonymizer.Config;
-using FhirPseudonymizer.Pseudonymization;
+using FhirPseudonymizer.Projects;
 using Microsoft.Health.Fhir.Anonymizer.Core;
 
 namespace FhirPseudonymizer;
@@ -11,11 +11,11 @@ public static class AnonymizerEngineExtensions
         AppConfig appConfig
     )
     {
+        // Registers the FHIRPath symbols every Engine's rules are written against, the Projects'
+        // as much as the server's own.
         AnonymizerEngine.InitializeFhirPathExtensionSymbols();
 
-        var configFilePath = appConfig.AnonymizationEngineConfigPath;
-
-        AnonymizerConfigurationManager anonConfigManager = null;
+        AnonymizerConfigurationManager anonConfigManager;
         if (!string.IsNullOrEmpty(appConfig.AnonymizationEngineConfigInline))
         {
             anonConfigManager = AnonymizerConfigurationManager.CreateFromYamlConfigString(
@@ -23,10 +23,10 @@ public static class AnonymizerEngineExtensions
                 appConfig.Anonymization
             );
         }
-        else if (!string.IsNullOrEmpty(configFilePath))
+        else if (!string.IsNullOrEmpty(appConfig.AnonymizationEngineConfigPath))
         {
             anonConfigManager = AnonymizerConfigurationManager.CreateFromYamlConfigFile(
-                configFilePath,
+                appConfig.AnonymizationEngineConfigPath,
                 appConfig.Anonymization
             );
         }
@@ -37,40 +37,21 @@ public static class AnonymizerEngineExtensions
             );
         }
 
-        // add the anon config as an additional service to allow mocking it
+        // Exposed for mocking, and shared by the singletons below.
         services.AddSingleton(_ => anonConfigManager);
 
+        // The Engines built from the server's own Config, which every request that names no
+        // Project is served with. A Project's are built the same way, by the same factory.
+        services.AddSingleton(sp =>
+            sp.GetRequiredService<IAnonymizerEngineFactory>()
+                .Create(sp.GetRequiredService<AnonymizerConfigurationManager>())
+        );
+
+        // The Kafka consumer path only ever runs the server's own rules, so it depends on this
+        // single engine rather than resolving a Project.
         services.AddSingleton<IAnonymizerEngine>(sp =>
-        {
-            var anonConfig = sp.GetRequiredService<AnonymizerConfigurationManager>();
-            var engine = new AnonymizerEngine(anonConfig);
-
-            var psnClient = sp.GetRequiredService<IPseudonymServiceClient>();
-            engine.AddProcessor(
-                "pseudonymize",
-                new PseudonymizationProcessor(psnClient, appConfig.Features)
-            );
-
-            return engine;
-        });
-
-        services.AddSingleton<IDePseudonymizerEngine>(sp =>
-        {
-            var anonConfig = sp.GetRequiredService<AnonymizerConfigurationManager>();
-            var engine = new DePseudonymizerEngine(anonConfig);
-
-            var psnClient = sp.GetRequiredService<IPseudonymServiceClient>();
-            engine.AddProcessor(
-                "pseudonymize",
-                new DePseudonymizationProcessor(psnClient, appConfig.Features)
-            );
-
-            engine.AddProcessor(
-                "encrypt",
-                new DecryptProcessor(anonConfig.GetParameterConfiguration().EncryptKey)
-            );
-            return engine;
-        });
+            sp.GetRequiredService<ProjectEngines>().Anonymizer
+        );
 
         return services;
     }

--- a/src/FhirPseudonymizer/ApiKeyExtensions.cs
+++ b/src/FhirPseudonymizer/ApiKeyExtensions.cs
@@ -5,6 +5,39 @@ namespace FhirPseudonymizer;
 
 public static class ApiKeyExtensions
 {
+    /// <summary>
+    ///     Guards Project registration: a Config carries crypto keys, and unbounded registration
+    ///     is a memory-exhaustion vector.
+    /// </summary>
+    public const string ProjectRegistrationPolicy = "ProjectRegistration";
+
+    /// <summary>
+    ///     Requires the API key for Project registration, but only when one is configured, so a
+    ///     deployment that sets no key stays reachable.
+    /// </summary>
+    public static IServiceCollection AddProjectRegistrationAuth(
+        this IServiceCollection services,
+        string apiKey
+    )
+    {
+        return services.AddAuthorization(options =>
+            options.AddPolicy(
+                ProjectRegistrationPolicy,
+                policy =>
+                {
+                    if (string.IsNullOrWhiteSpace(apiKey))
+                    {
+                        policy.RequireAssertion(_ => true);
+                        return;
+                    }
+
+                    policy.AddAuthenticationSchemes(ApiKeyDefaults.AuthenticationScheme);
+                    policy.RequireAuthenticatedUser();
+                }
+            )
+        );
+    }
+
     public static IServiceCollection AddApiKeyAuth(this IServiceCollection services, string apiKey)
     {
         services

--- a/src/FhirPseudonymizer/Config/AppConfig.cs
+++ b/src/FhirPseudonymizer/Config/AppConfig.cs
@@ -11,6 +11,15 @@ public record AppConfig
     public string ApiKey { get; init; }
     public PseudonymizationServiceType PseudonymizationService { get; init; }
     public CacheConfig Cache { get; init; } = new();
+
+    /// <summary>
+    ///     Bounds the Project registry. The size limit is carried here and not left to
+    ///     appsettings.json alone: a deployment that does not layer that file would otherwise bind
+    ///     the zero a <see cref="CacheConfig" /> starts at, which the registry refuses. The
+    ///     expirations do default to 0, because that disables them — a Project should stay usable
+    ///     for as long as it fits.
+    /// </summary>
+    public CacheConfig ProjectCache { get; init; } = new() { SizeLimit = 128 };
     public GPasConfig GPas { get; init; } = new();
     public VfpsConfig Vfps { get; init; } = new();
     public EnticiConfig Entici { get; init; } = new();

--- a/src/FhirPseudonymizer/Config/CacheEntryExtensions.cs
+++ b/src/FhirPseudonymizer/Config/CacheEntryExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace FhirPseudonymizer.Config;
+
+public static class CacheEntryExtensions
+{
+    /// <summary>
+    ///     Sizes and expires a cache entry according to a <see cref="CacheConfig" />: every entry
+    ///     counts as 1 towards the cache's size limit, and an expiration left at 0 stays disabled.
+    /// </summary>
+    public static void ApplyCacheConfig(this ICacheEntry entry, CacheConfig cacheConfig)
+    {
+        entry.SetSize(1);
+
+        if (cacheConfig.SlidingExpirationMinutes > 0)
+        {
+            entry.SetSlidingExpiration(TimeSpan.FromMinutes(cacheConfig.SlidingExpirationMinutes));
+        }
+
+        if (cacheConfig.AbsoluteExpirationMinutes > 0)
+        {
+            entry.SetAbsoluteExpiration(
+                TimeSpan.FromMinutes(cacheConfig.AbsoluteExpirationMinutes)
+            );
+        }
+    }
+}

--- a/src/FhirPseudonymizer/Controllers/FhirController.cs
+++ b/src/FhirPseudonymizer/Controllers/FhirController.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using FhirPseudonymizer.Config;
 using FhirPseudonymizer.Kafka;
+using FhirPseudonymizer.Projects;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -37,34 +38,28 @@ namespace FhirPseudonymizer.Controllers
             }
         );
 
-        private readonly IAnonymizerEngine anonymizer;
         private readonly AnonymizationConfig config;
-        private readonly IDePseudonymizerEngine dePseudonymizer;
+        private readonly ProjectEngines serverEngines;
         private readonly IProvenancePublisher provenancePublisher;
         private readonly ILogger<FhirController> logger;
+        private readonly IProjectRegistry projectRegistry;
 
         public FhirController(
             AnonymizationConfig config,
             ILogger<FhirController> logger,
-            IAnonymizerEngine anonymizer,
-            IDePseudonymizerEngine dePseudonymizer,
-            IProvenancePublisher provenancePublisher
+            ProjectEngines serverEngines,
+            IProvenancePublisher provenancePublisher,
+            IProjectRegistry projectRegistry
         )
         {
             this.config = config;
             this.logger = logger;
-            this.anonymizer = anonymizer;
-            this.dePseudonymizer = dePseudonymizer;
+            this.serverEngines = serverEngines;
             this.provenancePublisher = provenancePublisher;
+            this.projectRegistry = projectRegistry;
 
-            BadRequestOutcome = new();
-            BadRequestOutcome.Issue.Add(
-                new OperationOutcome.IssueComponent
-                {
-                    Severity = OperationOutcome.IssueSeverity.Error,
-                    Code = OperationOutcome.IssueType.Processing,
-                    Diagnostics = "Received malformed or missing resource",
-                }
+            BadRequestOutcome = OperationOutcomes.BadRequest(
+                "Received malformed or missing resource"
             );
         }
 
@@ -76,7 +71,8 @@ namespace FhirPseudonymizer.Controllers
         /// </summary>
         /// <param name="resource">
         ///     The FHIR resource to be de-identified. If the resource is of type 'Parameters' then the input is
-        ///     fetched from the parameter named 'resource'.
+        ///     fetched from the parameter named 'resource', and a registered Project's config is selected by the
+        ///     (optional) 'project' parameter.
         /// </param>
         /// <returns>The de-identified resource.</returns>
         /// <response code="200">Returns the de-identified resource</response>
@@ -84,6 +80,7 @@ namespace FhirPseudonymizer.Controllers
         [AllowAnonymous]
         [ProducesResponseType(typeof(Resource), 200)]
         [ProducesResponseType(typeof(OperationOutcome), 400)]
+        [ProducesResponseType(typeof(OperationOutcome), 404)]
         [ProducesResponseType(typeof(OperationOutcome), 500)]
         public async Task<ObjectResult> DeIdentify([FromBody] Resource resource)
         {
@@ -98,6 +95,11 @@ namespace FhirPseudonymizer.Controllers
                 resource.TypeName,
                 resource.Id
             );
+
+            if (!TryResolveEngines(resource, out var engines, out var failure))
+            {
+                return failure;
+            }
 
             var settings = new AnonymizerSettings()
             {
@@ -130,15 +132,131 @@ namespace FhirPseudonymizer.Controllers
                     return BadRequest(BadRequestOutcome);
                 }
 
-                return await Anonymize(innerResource, settings);
+                return await Anonymize(innerResource, settings, engines);
             }
 
-            return await Anonymize(resource, settings);
+            return await Anonymize(resource, settings, engines);
+        }
+
+        /// <summary>
+        ///     Picks the Engines a request is served with: a registered Project's when the
+        ///     (optional) 'project' parameter of a Parameters body names one, otherwise the ones
+        ///     built from the startup config. A bare resource names no Project.
+        /// </summary>
+        /// <returns>
+        ///     False when the request cannot be served, with <c>failure</c> set to the response to
+        ///     send instead.
+        /// </returns>
+        private bool TryResolveEngines(
+            Resource resource,
+            out ProjectEngines engines,
+            out ObjectResult failure
+        )
+        {
+            failure = null;
+            engines = serverEngines;
+
+            // Not GetSingle, which throws on a duplicated name — a caller's mistake that has to
+            // answer 400, not 500.
+            var selectors = (resource as Parameters)?.Get("project").ToList();
+            if (selectors is null or [])
+            {
+                return true;
+            }
+
+            if (selectors.Count > 1)
+            {
+                failure = AmbiguousProjectSelection(selectors.Count);
+                return false;
+            }
+
+            var selector = selectors[0];
+
+            // A 'project' parameter the server cannot read a name out of is refused rather than
+            // served with the server's own config: the caller asked for a Project's rules, so
+            // quietly applying different ones would hand back data they believe was de-identified
+            // some other way. A name registration would reject gets the same answer instead of the
+            // 404 below, whose re-register-and-retry advice could never resolve it.
+            if (selector.Value is not FhirString name || !ProjectName.IsValid(name.Value))
+            {
+                failure = UnusableProjectName(selector.Value);
+                return false;
+            }
+
+            if (projectRegistry.TryGet(name.Value, out engines))
+            {
+                return true;
+            }
+
+            failure = UnknownProject(name.Value);
+            return false;
+        }
+
+        /// <summary>
+        ///     Refuses a request carrying the 'project' parameter more than once: the server
+        ///     cannot tell which of the named configs the caller expects to run, and picking one
+        ///     would be as invisible as the fallback the single-parameter checks refuse.
+        /// </summary>
+        private ObjectResult AmbiguousProjectSelection(int count)
+        {
+            // Only the count is logged: the names are as unvetted as any other rejected selector.
+            logger.LogWarning(
+                "Rejected a request carrying {parameterCount} 'project' parameters",
+                count
+            );
+
+            return BadRequest(
+                OperationOutcomes.BadRequest(
+                    "The 'project' parameter must not appear more than once."
+                )
+            );
+        }
+
+        /// <summary>
+        ///     Refuses a 'project' parameter that names nothing that could ever be registered.
+        /// </summary>
+        private ObjectResult UnusableProjectName(DataType value)
+        {
+            // The value's FHIR type name is a fixed vocabulary, unlike the name it would carry,
+            // so it can be logged as it is.
+            logger.LogWarning(
+                "Rejected a request whose 'project' parameter carries no usable name ({parameterType})",
+                value?.TypeName ?? "no value"
+            );
+
+            return BadRequest(
+                OperationOutcomes.BadRequest(
+                    "The 'project' parameter must carry a valueString naming a registered project. "
+                        + ProjectName.Rule
+                )
+            );
+        }
+
+        /// <summary>
+        ///     Refuses a request naming a Project this server does not hold. A miss is expected —
+        ///     a restart, scale-out or eviction all produce one — so the caller is told to
+        ///     re-register and retry.
+        /// </summary>
+        private ObjectResult UnknownProject(string projectName)
+        {
+            logger.LogInformation(
+                "Received a request for the unknown project {projectName}",
+                projectName.ForLog()
+            );
+
+            // Safe to quote back: the name passed the same check registration applies, so it is
+            // bounded and holds nothing a response or a log line has to be protected from.
+            return NotFound(
+                OperationOutcomes.NotFound(
+                    $"Unknown project '{projectName}'. Register its config via PUT /projects/{projectName} and retry."
+                )
+            );
         }
 
         private async Task<ObjectResult> Anonymize(
             Resource resource,
-            AnonymizerSettings anonymizerSettings
+            AnonymizerSettings anonymizerSettings,
+            ProjectEngines engines
         )
         {
             using var activity = Program.ActivitySource.StartActivity(nameof(Anonymize));
@@ -153,22 +271,31 @@ namespace FhirPseudonymizer.Controllers
 
             try
             {
-                var anonymized = await anonymizer.AnonymizeResourceAsync(
+                var anonymized = await engines.Anonymizer.AnonymizeResourceAsync(
                     resource,
                     anonymizerSettings
                 );
+
+                // Provenance is published for Project-scoped requests too: it records only that a
+                // de-identification happened and the before/after identity of the resource it
+                // happened to, never which rules ran, so nothing in it is specific to the engine
+                // that produced it and no Project name can enter the record. Exempting them would
+                // blind the audit trail exactly where the applied rules are least predictable.
                 provenancePublisher.Publish(resource, anonymized);
                 return Ok(anonymized);
             }
             catch (Exception exc)
             {
                 logger.LogError(exc, "Anonymize failed");
-                return StatusCode(500, GetInternalErrorOutcome(exc));
+                return StatusCode(500, OperationOutcomes.InternalError(exc));
             }
         }
 
         /// <summary>
         ///     Revert any reversible de-identification methods previously applied to the given FHIR resource.
+        ///     Always served with the server's own config, never a Project's: a Project carries its own
+        ///     keys, so reversing its output through this API would cross the boundary that keeps one
+        ///     Project from reading another's data.
         /// </summary>
         /// <param name="resource">The FHIR resource containing pseudonymized fields that are to be de-pseudonymized.</param>
         /// <returns>The modified FHIR resource with the pseudonymized fields replaced with the original value.</returns>
@@ -199,12 +326,14 @@ namespace FhirPseudonymizer.Controllers
 
             try
             {
-                return Ok(await dePseudonymizer.DePseudonymizeResourceAsync(resource));
+                return Ok(
+                    await serverEngines.DePseudonymizer.DePseudonymizeResourceAsync(resource)
+                );
             }
             catch (Exception exc)
             {
                 logger.LogError(exc, "DePseudonymize failed");
-                return StatusCode(500, GetInternalErrorOutcome(exc));
+                return StatusCode(500, OperationOutcomes.InternalError(exc));
             }
         }
 
@@ -232,21 +361,6 @@ namespace FhirPseudonymizer.Controllers
                     new() { Mode = CapabilityStatement.RestfulCapabilityMode.Server },
                 },
             };
-        }
-
-        private static OperationOutcome GetInternalErrorOutcome(Exception exc)
-        {
-            var outcome = new OperationOutcome();
-            outcome.Issue.Add(
-                new OperationOutcome.IssueComponent
-                {
-                    Severity = OperationOutcome.IssueSeverity.Fatal,
-                    Code = OperationOutcome.IssueType.Processing,
-                    Diagnostics =
-                        $"An internal error occurred when processing the request: {exc.Message}.\nAt: {exc.StackTrace}",
-                }
-            );
-            return outcome;
         }
     }
 }

--- a/src/FhirPseudonymizer/Controllers/LogSafeText.cs
+++ b/src/FhirPseudonymizer/Controllers/LogSafeText.cs
@@ -1,0 +1,28 @@
+namespace FhirPseudonymizer.Controllers;
+
+/// <summary>
+///     Renders caller-supplied text fit for a log line.
+/// </summary>
+internal static class LogSafeText
+{
+    /// <summary>
+    ///     The longest a project name may legitimately be, so nothing a caller could register is
+    ///     ever cut.
+    /// </summary>
+    private const int MaxLength = 64;
+
+    /// <summary>
+    ///     A project name reaches the log unvetted — from a route segment before the name check
+    ///     runs, or from a Parameters body, which nothing bounds at all. Dropping the line breaks
+    ///     stops a '%0A' in it from forging a second entry; the cut stops a long one from burying
+    ///     the rest of the line.
+    /// </summary>
+    public static string ForLog(this string value)
+    {
+        var oneLine = value.ReplaceLineEndings(string.Empty);
+
+        return oneLine.Length > MaxLength
+            ? string.Concat(oneLine.AsSpan(0, MaxLength), "…")
+            : oneLine;
+    }
+}

--- a/src/FhirPseudonymizer/Controllers/OperationOutcomes.cs
+++ b/src/FhirPseudonymizer/Controllers/OperationOutcomes.cs
@@ -1,0 +1,66 @@
+using Hl7.Fhir.Model;
+
+namespace FhirPseudonymizer.Controllers;
+
+/// <summary>
+///     Builds the <see cref="OperationOutcome" /> resources the API reports failures with.
+/// </summary>
+public static class OperationOutcomes
+{
+    public static OperationOutcome BadRequest(string diagnostics)
+    {
+        return Create(
+            OperationOutcome.IssueSeverity.Error,
+            OperationOutcome.IssueType.Processing,
+            diagnostics
+        );
+    }
+
+    public static OperationOutcome NotFound(string diagnostics)
+    {
+        return Create(
+            OperationOutcome.IssueSeverity.Error,
+            OperationOutcome.IssueType.NotFound,
+            diagnostics
+        );
+    }
+
+    /// <summary>
+    ///     A transient refusal the caller is expected to retry.
+    /// </summary>
+    public static OperationOutcome TryLater(string diagnostics)
+    {
+        return Create(
+            OperationOutcome.IssueSeverity.Error,
+            OperationOutcome.IssueType.Transient,
+            diagnostics
+        );
+    }
+
+    public static OperationOutcome InternalError(Exception exc)
+    {
+        return Create(
+            OperationOutcome.IssueSeverity.Fatal,
+            OperationOutcome.IssueType.Processing,
+            $"An internal error occurred when processing the request: {exc.Message}.\nAt: {exc.StackTrace}"
+        );
+    }
+
+    private static OperationOutcome Create(
+        OperationOutcome.IssueSeverity severity,
+        OperationOutcome.IssueType code,
+        string diagnostics
+    )
+    {
+        var outcome = new OperationOutcome();
+        outcome.Issue.Add(
+            new OperationOutcome.IssueComponent
+            {
+                Severity = severity,
+                Code = code,
+                Diagnostics = diagnostics,
+            }
+        );
+        return outcome;
+    }
+}

--- a/src/FhirPseudonymizer/Controllers/ProjectsController.cs
+++ b/src/FhirPseudonymizer/Controllers/ProjectsController.cs
@@ -1,0 +1,106 @@
+using FhirPseudonymizer.Projects;
+using Hl7.Fhir.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FhirPseudonymizer.Controllers;
+
+/// <summary>
+///     Registers the anonymization Config a Project's requests are served with.
+/// </summary>
+[ApiController]
+[Route("[controller]")]
+[Produces("application/fhir+json")]
+[Authorize(Policy = ApiKeyExtensions.ProjectRegistrationPolicy)]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+public class ProjectsController(IProjectRegistry registry, ILogger<ProjectsController> logger)
+    : ControllerBase
+{
+    /// <summary>
+    ///     Register a Project's anonymization Config so later requests can select it by name.
+    /// </summary>
+    /// <param name="name">The caller-chosen Project name.</param>
+    /// <returns>No content.</returns>
+    /// <response code="200">An earlier config for this Project was replaced.</response>
+    /// <response code="201">The Project was registered.</response>
+    /// <response code="400">The config could not be parsed or is not a usable anonymization config.</response>
+    /// <response code="503">The registry is full; retry shortly.</response>
+    [HttpPut("{name}")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(201)]
+    [ProducesResponseType(typeof(OperationOutcome), 400)]
+    [ProducesResponseType(typeof(OperationOutcome), 503)]
+    public async Task<IActionResult> Register(string name)
+    {
+        var loggedName = name.ForLog();
+
+        if (!ProjectName.IsValid(name))
+        {
+            logger.LogWarning("Rejected the unusable project name {projectName}", loggedName);
+
+            return BadRequest(
+                OperationOutcomes.BadRequest($"Invalid project name. {ProjectName.Rule}")
+            );
+        }
+
+        // Read the YAML straight off the request body: the registered input formatters are
+        // FHIR-JSON only, so a [FromBody] parameter would reject an application/yaml payload.
+        using var reader = new StreamReader(Request.Body);
+        var yamlConfig = await reader.ReadToEndAsync();
+
+        ProjectRegistrationOutcome outcome;
+        try
+        {
+            outcome = registry.Register(name, yamlConfig);
+        }
+        catch (InvalidProjectConfigException exc)
+        {
+            logger.LogWarning(
+                exc,
+                "Rejected the config offered for project {projectName}",
+                loggedName
+            );
+            return BadRequest(OperationOutcomes.BadRequest(exc.Message));
+        }
+
+        if (outcome == ProjectRegistrationOutcome.NotStored)
+        {
+            logger.LogWarning(
+                "Could not store project {projectName}: the registry is at its size limit",
+                loggedName
+            );
+
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                OperationOutcomes.TryLater(
+                    "The project registry is full. Reaching the limit triggers a compaction, so retry shortly."
+                )
+            );
+        }
+
+        logger.LogInformation("Registered project {projectName} ({outcome})", loggedName, outcome);
+
+        return outcome switch
+        {
+            ProjectRegistrationOutcome.Replaced => Ok(),
+            _ => StatusCode(StatusCodes.Status201Created),
+        };
+    }
+
+    /// <summary>
+    ///     Release a Project, so requests naming it are answered with a 404 again.
+    /// </summary>
+    /// <param name="name">The Project name.</param>
+    /// <returns>No content.</returns>
+    /// <response code="204">The Project is no longer registered here.</response>
+    [HttpDelete("{name}")]
+    [ProducesResponseType(204)]
+    public IActionResult Unregister(string name)
+    {
+        // Idempotent: the registry is a cache, so "was never here" and "is no longer here" are
+        // the same state to the caller.
+        registry.Remove(name);
+
+        return NoContent();
+    }
+}

--- a/src/FhirPseudonymizer/Projects/AnonymizerEngineFactory.cs
+++ b/src/FhirPseudonymizer/Projects/AnonymizerEngineFactory.cs
@@ -1,0 +1,35 @@
+using FhirPseudonymizer.Config;
+using FhirPseudonymizer.Pseudonymization;
+using Microsoft.Health.Fhir.Anonymizer.Core;
+
+namespace FhirPseudonymizer.Projects;
+
+public class AnonymizerEngineFactory(
+    IPseudonymServiceClient pseudonymServiceClient,
+    FeatureManagement features
+) : IAnonymizerEngineFactory
+{
+    public ProjectEngines Create(AnonymizerConfigurationManager configManager)
+    {
+        var anonymizer = new AnonymizerEngine(configManager);
+        anonymizer.AddProcessor(
+            "pseudonymize",
+            new PseudonymizationProcessor(pseudonymServiceClient, features)
+        );
+
+        var dePseudonymizer = new DePseudonymizerEngine(configManager);
+        dePseudonymizer.AddProcessor(
+            "pseudonymize",
+            new DePseudonymizationProcessor(pseudonymServiceClient, features)
+        );
+
+        // The encrypt key comes from the Config's own parameters, which is what lets each
+        // Project decrypt with its own key.
+        dePseudonymizer.AddProcessor(
+            "encrypt",
+            new DecryptProcessor(configManager.GetParameterConfiguration().EncryptKey)
+        );
+
+        return new ProjectEngines(anonymizer, dePseudonymizer);
+    }
+}

--- a/src/FhirPseudonymizer/Projects/IAnonymizerEngineFactory.cs
+++ b/src/FhirPseudonymizer/Projects/IAnonymizerEngineFactory.cs
@@ -1,0 +1,12 @@
+using Microsoft.Health.Fhir.Anonymizer.Core;
+
+namespace FhirPseudonymizer.Projects;
+
+/// <summary>
+///     Builds the Engines for one Config. Used both for the startup Config and for every
+///     registered Project.
+/// </summary>
+public interface IAnonymizerEngineFactory
+{
+    ProjectEngines Create(AnonymizerConfigurationManager configManager);
+}

--- a/src/FhirPseudonymizer/Projects/IProjectRegistry.cs
+++ b/src/FhirPseudonymizer/Projects/IProjectRegistry.cs
@@ -1,0 +1,29 @@
+namespace FhirPseudonymizer.Projects;
+
+/// <summary>
+///     Caches the Engines built for each registered Project. It is a cache, not a store: the
+///     client owns the authoritative Config, so an unknown Project name is a normal outcome.
+/// </summary>
+public interface IProjectRegistry
+{
+    ProjectRegistrationOutcome Register(string name, string yamlConfig);
+
+    bool TryGet(string name, out ProjectEngines engines);
+
+    void Remove(string name);
+}
+
+public enum ProjectRegistrationOutcome
+{
+    /// <summary>The Project was not registered here before.</summary>
+    Created,
+
+    /// <summary>An earlier Config for this Project name was replaced.</summary>
+    Replaced,
+
+    /// <summary>
+    ///     The registry was full, so the entry was dropped. Retryable: reaching the bound
+    ///     triggers a compaction that frees space.
+    /// </summary>
+    NotStored,
+}

--- a/src/FhirPseudonymizer/Projects/InvalidProjectConfigException.cs
+++ b/src/FhirPseudonymizer/Projects/InvalidProjectConfigException.cs
@@ -1,0 +1,8 @@
+namespace FhirPseudonymizer.Projects;
+
+/// <summary>
+///     Thrown when a Project's Config cannot produce Engines. This is always the caller's
+///     mistake, so registration answers it with a 400 rather than a 500.
+/// </summary>
+public class InvalidProjectConfigException(string message, Exception innerException = null)
+    : Exception(message, innerException);

--- a/src/FhirPseudonymizer/Projects/ProjectEngines.cs
+++ b/src/FhirPseudonymizer/Projects/ProjectEngines.cs
@@ -1,0 +1,12 @@
+using Microsoft.Health.Fhir.Anonymizer.Core;
+
+namespace FhirPseudonymizer.Projects;
+
+/// <summary>
+///     The pair of Engines built from one Project's Config: one to anonymize and one to
+///     de-pseudonymize. They share the Config, and therefore the Project's crypto keys.
+/// </summary>
+public sealed record ProjectEngines(
+    IAnonymizerEngine Anonymizer,
+    IDePseudonymizerEngine DePseudonymizer
+);

--- a/src/FhirPseudonymizer/Projects/ProjectName.cs
+++ b/src/FhirPseudonymizer/Projects/ProjectName.cs
@@ -1,0 +1,33 @@
+using System.Text.RegularExpressions;
+
+namespace FhirPseudonymizer.Projects;
+
+/// <summary>
+///     The rule a Project name has to satisfy. Shared by the endpoint that registers a Project and
+///     the one that selects it: a name registration would refuse can never name a registered
+///     Project, so a request carrying one is a caller's mistake rather than a miss.
+/// </summary>
+public static partial class ProjectName
+{
+    /// <summary>
+    ///     States the rule to a caller who broke it. It deliberately does not quote the offending
+    ///     name back: the caller sent it, and nothing bounds the one a request body carries but
+    ///     the body size limit.
+    /// </summary>
+    public const string Rule =
+        "A name may hold up to 64 characters, each of them a letter, a digit, '.', '_' or '-'.";
+
+    /// <summary>
+    ///     A name is both the registry key and part of the registration route, so the charset is
+    ///     kept to what is safe and unambiguous there, and the length bound keeps a caller from
+    ///     naming absurdly long keys. Anchored with '\z' because '$' also matches before a
+    ///     trailing newline, which Kestrel decodes out of an %0A in the route.
+    /// </summary>
+    [GeneratedRegex(@"^[A-Za-z0-9._-]{1,64}\z")]
+    private static partial Regex Pattern();
+
+    public static bool IsValid(string name)
+    {
+        return name is not null && Pattern().IsMatch(name);
+    }
+}

--- a/src/FhirPseudonymizer/Projects/ProjectRegistry.cs
+++ b/src/FhirPseudonymizer/Projects/ProjectRegistry.cs
@@ -1,0 +1,189 @@
+using FhirPseudonymizer.Config;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Health.Fhir.Anonymizer.Core;
+using Microsoft.Health.Fhir.Anonymizer.Core.AnonymizerConfigurations;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using AnonymizerConstants = Microsoft.Health.Fhir.Anonymizer.Core.Constants;
+
+namespace FhirPseudonymizer.Projects;
+
+public class ProjectRegistry : IProjectRegistry, IDisposable
+{
+    private readonly MemoryCache cache;
+    private readonly CacheConfig cacheConfig;
+    private readonly IAnonymizerEngineFactory engineFactory;
+    private readonly Lock mutationLock = new();
+
+    public ProjectRegistry(IAnonymizerEngineFactory engineFactory, CacheConfig cacheConfig)
+    {
+        // A zero size limit would reject every entry, so each registration would answer 503
+        // promising a retry that cannot succeed.
+        if (cacheConfig.SizeLimit == 0)
+        {
+            throw new InvalidOperationException(
+                "ProjectCache:SizeLimit must be greater than 0: the project registry cannot "
+                    + "store anything in a zero-sized cache. Raise the limit or leave it at "
+                    + "its default."
+            );
+        }
+
+        this.engineFactory = engineFactory;
+        this.cacheConfig = cacheConfig;
+
+        // One entry's worth, which is what a rejected registration needs and all it should cost:
+        // every evicted Project is a caller whose next request 404s and who has to register again.
+        // The default 5% would both floor to zero evictions below a limit of 20 — leaving a full
+        // registry answering 503 while promising a retry would succeed — and evict far more than
+        // one above it (6 at the default limit of 128, 50 at 1000).
+        cache = new MemoryCache(
+            new MemoryCacheOptions
+            {
+                SizeLimit = cacheConfig.SizeLimit,
+                CompactionPercentage = 1.0 / cacheConfig.SizeLimit,
+            }
+        );
+    }
+
+    public ProjectRegistrationOutcome Register(string name, string yamlConfig)
+    {
+        // Engines are built eagerly so a broken config is reported at registration, not on the
+        // first bundle naming this Project.
+        var engines = engineFactory.Create(ParseConfig(yamlConfig));
+
+        // The outcome is derived from three cache operations, so they are serialized: otherwise
+        // two concurrent registrations of the same new name could both answer 201, and a removal
+        // between the store and the re-check would read as a full registry.
+        lock (mutationLock)
+        {
+            var replacesExisting = cache.TryGetValue(name, out _);
+
+            using (var entry = cache.CreateEntry(name))
+            {
+                entry.ApplyCacheConfig(cacheConfig);
+                entry.Value = engines;
+            }
+
+            // MemoryCache does not evict to make room: over the size bound it drops the *new*
+            // entry and compacts in the background, so the store has to be confirmed.
+            if (!cache.TryGetValue(name, out _))
+            {
+                return ProjectRegistrationOutcome.NotStored;
+            }
+
+            return replacesExisting
+                ? ProjectRegistrationOutcome.Replaced
+                : ProjectRegistrationOutcome.Created;
+        }
+    }
+
+    /// <summary>
+    ///     Deserializes and validates a Project's Config, reporting every way it can fail as an
+    ///     <see cref="InvalidProjectConfigException" /> so registration can answer with a 400.
+    /// </summary>
+    private static AnonymizerConfigurationManager ParseConfig(string yamlConfig)
+    {
+        AnonymizerConfiguration config;
+        try
+        {
+            config = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build()
+                .Deserialize<AnonymizerConfiguration>(yamlConfig);
+        }
+        catch (YamlException exc)
+        {
+            throw new InvalidProjectConfigException(
+                $"The project config is not valid YAML: {exc.Message}",
+                exc
+            );
+        }
+
+        if (config is null)
+        {
+            throw new InvalidProjectConfigException("The project config is empty.");
+        }
+
+        // Valid YAML can still carry an empty list item (a bare '-' or an explicit null), which
+        // no downstream consumer of the rules guards against.
+        if (config.FhirPathRules?.Any(rule => rule is null) == true)
+        {
+            throw new InvalidProjectConfigException(
+                "The project config contains an empty rule element in 'fhirPathRules'."
+            );
+        }
+
+        // Must run before the manager is built: its constructor fills absent keys with a
+        // process-wide default, which would silently key a Project's data with a shared secret.
+        RequireKeysForRules(config);
+
+        try
+        {
+            // A Project's keys must come from its own Config, so the AnonymizationConfig
+            // fallback argument is omitted.
+            return new AnonymizerConfigurationManager(config);
+        }
+        catch (AnonymizerConfigurationErrorsException exc)
+        {
+            throw new InvalidProjectConfigException(
+                $"The project config is invalid: {exc.Message}",
+                exc
+            );
+        }
+    }
+
+    /// <summary>
+    ///     Rejects a Config that uses a keyed method without carrying the key itself. A Project's
+    ///     keys come only from its own Config, so a rule missing its key can never do what its
+    ///     author intended.
+    /// </summary>
+    private static void RequireKeysForRules(AnonymizerConfiguration config)
+    {
+        var methods =
+            config
+                .FhirPathRules?.Where(rule => rule.ContainsKey(AnonymizerConstants.MethodKey))
+                .Select(rule => rule[AnonymizerConstants.MethodKey]?.ToString())
+                .ToHashSet(StringComparer.InvariantCultureIgnoreCase)
+            ?? [];
+
+        RequireKey(methods, "encrypt", "encryptKey", config.Parameters?.EncryptKey);
+        RequireKey(methods, "cryptoHash", "cryptoHashKey", config.Parameters?.CryptoHashKey);
+        RequireKey(methods, "dateShift", "dateShiftKey", config.Parameters?.DateShiftKey);
+    }
+
+    private static void RequireKey(
+        IReadOnlySet<string> methods,
+        string method,
+        string parameterName,
+        string key
+    )
+    {
+        if (methods.Contains(method) && string.IsNullOrWhiteSpace(key))
+        {
+            throw new InvalidProjectConfigException(
+                $"The project config uses the '{method}' method but carries no 'parameters.{parameterName}'. "
+                    + "Projects do not inherit the server's keys, so the key must be part of the config."
+            );
+        }
+    }
+
+    public bool TryGet(string name, out ProjectEngines engines)
+    {
+        return cache.TryGetValue(name, out engines);
+    }
+
+    public void Remove(string name)
+    {
+        lock (mutationLock)
+        {
+            cache.Remove(name);
+        }
+    }
+
+    public void Dispose()
+    {
+        cache.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/FhirPseudonymizer/Pseudonymization/CachedPseudonymServiceClient.cs
+++ b/src/FhirPseudonymizer/Pseudonymization/CachedPseudonymServiceClient.cs
@@ -39,7 +39,7 @@ public class CachedPseudonymServiceClient(
                 TotalPseudonymizationRequestCacheMisses
                     .WithLabels(nameof(GetOrCreatePseudonymFor))
                     .Inc();
-                ApplyCacheConfig(entry);
+                entry.ApplyCacheConfig(cacheConfig);
                 return await innerClient.GetOrCreatePseudonymFor(value, domain, settings);
             }
         );
@@ -60,7 +60,7 @@ public class CachedPseudonymServiceClient(
                 TotalPseudonymizationRequestCacheMisses
                     .WithLabels(nameof(GetOriginalValueFor))
                     .Inc();
-                ApplyCacheConfig(entry);
+                entry.ApplyCacheConfig(cacheConfig);
                 return await innerClient.GetOriginalValueFor(pseudonym, domain, settings);
             }
         );
@@ -74,22 +74,5 @@ public class CachedPseudonymServiceClient(
         }
 
         return JsonSerializer.Serialize(settings);
-    }
-
-    private void ApplyCacheConfig(ICacheEntry entry)
-    {
-        entry.SetSize(1);
-
-        if (cacheConfig.SlidingExpirationMinutes > 0)
-        {
-            entry.SetSlidingExpiration(TimeSpan.FromMinutes(cacheConfig.SlidingExpirationMinutes));
-        }
-
-        if (cacheConfig.AbsoluteExpirationMinutes > 0)
-        {
-            entry.SetAbsoluteExpiration(
-                TimeSpan.FromMinutes(cacheConfig.AbsoluteExpirationMinutes)
-            );
-        }
     }
 }

--- a/src/FhirPseudonymizer/Startup.cs
+++ b/src/FhirPseudonymizer/Startup.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FhirPseudonymizer.Config;
 using FhirPseudonymizer.Kafka;
+using FhirPseudonymizer.Projects;
 using FhirPseudonymizer.Pseudonymization;
 using FhirPseudonymizer.Pseudonymization.Entici;
 using FhirPseudonymizer.Pseudonymization.GPas;
@@ -48,6 +49,7 @@ public class Startup
         services.AddSingleton(_ => appConfig.Anonymization);
 
         services.AddApiKeyAuth(appConfig.ApiKey);
+        services.AddProjectRegistrationAuth(appConfig.ApiKey);
 
         // Required by the OAuth implementation. Could be used for all cache implementations later.
         services.AddDistributedMemoryCache();
@@ -75,6 +77,15 @@ public class Startup
                 services.AddTransient<IPseudonymServiceClient, NoopPseudonymServiceClient>();
                 break;
         }
+
+        services.AddSingleton<IAnonymizerEngineFactory, AnonymizerEngineFactory>();
+
+        // Constructed by hand because it owns its own MemoryCache and CacheConfig, which the
+        // container cannot tell apart from the pseudonym cache's by type.
+        services.AddSingleton<IProjectRegistry>(sp => new ProjectRegistry(
+            sp.GetRequiredService<IAnonymizerEngineFactory>(),
+            appConfig.ProjectCache
+        ));
 
         services.AddAnonymizerEngine(appConfig);
 
@@ -153,6 +164,12 @@ public class Startup
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
+        // Built here rather than on the first request that needs it: the registry rejects a size
+        // limit it cannot store anything in, and FhirController takes it as a dependency, so a
+        // bad limit would otherwise let the server report itself healthy and then fail every
+        // $de-identify — including on deployments that never register a project.
+        app.ApplicationServices.GetRequiredService<IProjectRegistry>();
+
         if (env.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();

--- a/src/FhirPseudonymizer/appsettings.json
+++ b/src/FhirPseudonymizer/appsettings.json
@@ -28,6 +28,11 @@
     "SlidingExpirationMinutes": 5,
     "AbsoluteExpirationMinutes": 30
   },
+  "ProjectCache": {
+    "SizeLimit": 128,
+    "SlidingExpirationMinutes": 0,
+    "AbsoluteExpirationMinutes": 0
+  },
   "gPAS": {
     "Url": "",
     "RequestRetryCount": 3,


### PR DESCRIPTION
## Summary

Today a deployment is pinned to the single `anonymization.yaml` it was started with, so serving a second study means running a second instance. This adds **projects**: a caller registers a named config at runtime and selects it per request.

```
PUT    /projects/{name}      register or replace a config   (201 / 200)
DELETE /projects/{name}      release one                    (204, idempotent)
POST   /fhir/$de-identify    select via a 'project' parameter in a Parameters body
```

```jsonc
{ "resourceType": "Parameters", "parameter": [
    { "name": "project",  "valueString": "my-study" },
    { "name": "resource", "resource": { "resourceType": "Patient", "id": "example" } } ] }
```

**Purely additive.** A bare resource, or a `Parameters` body without a `project`, is served with the server's own config exactly as before — no header, no change to any existing caller. `$de-identify` is the only operation that selects a project; `$de-pseudonymize` is always served with the server's own config.

The server still requires a config of its own. Projects are an addition to it, not a replacement, so a deployment setting neither `AnonymizationEngineConfigPath` nor `AnonymizationEngineConfigInline` still refuses to start.

## New configuration

| Variable | Description | Default |
| --- | --- | --- |
| `ProjectCache__SizeLimit` | How many projects may be registered at once; beyond it, `503`. Bounds the memory a caller can claim, so it is not optional (`0` fails fast at startup). | `128` |
| `ProjectCache__SlidingExpirationMinutes` | Drop a project this long after last use. `0` disables. | `0` |
| `ProjectCache__AbsoluteExpirationMinutes` | Drop a project this long after registration, used or not. `0` disables. | `0` |
