### PR TITLE
fix: answer 400 instead of 500 for a Parameters body without a resource

### DIFF
--- a/src/FhirPseudonymizer.Tests/FhirControllerTests.cs
+++ b/src/FhirPseudonymizer.Tests/FhirControllerTests.cs
@@ -92,6 +92,24 @@ public class FhirControllerTests
     }
 
     [Fact]
+    public async Task DeIdentify_WithParametersCarryingNoResource_ShouldReturnBadRequest()
+    {
+        var controller = new FhirController(
+            A.Fake<AnonymizationConfig>(),
+            A.Fake<ILogger<FhirController>>(),
+            A.Fake<IAnonymizerEngine>(),
+            A.Fake<IDePseudonymizerEngine>(),
+            A.Fake<IProvenancePublisher>()
+        );
+
+        var response = await controller.DeIdentify(new Parameters());
+
+        response.StatusCode.Should().Be(400);
+
+        response.Value.Should().BeOfType<OperationOutcome>();
+    }
+
+    [Fact]
     public async Task DeIdentify_PublishesProvenanceForTheOriginalAndAnonymizedResource()
     {
         var original = new Patient { Id = "123" };

--- a/src/FhirPseudonymizer/Controllers/FhirController.cs
+++ b/src/FhirPseudonymizer/Controllers/FhirController.cs
@@ -116,7 +116,16 @@ namespace FhirPseudonymizer.Controllers
                     );
                 }
 
-                return await Anonymize(param.GetSingle("resource").Resource, settings);
+                var innerResource = param.GetSingle("resource")?.Resource;
+                if (innerResource is null)
+                {
+                    logger.LogWarning(
+                        "Bad Request: received Parameters carry no 'resource' parameter."
+                    );
+                    return BadRequest(BadRequestOutcome);
+                }
+
+                return await Anonymize(innerResource, settings);
             }
 
             return await Anonymize(resource, settings);


### PR DESCRIPTION
Closes #356.

`Parameters.GetSingle("resource")` returns `null` when the parameter is absent, so the unguarded `.Resource` in `DeIdentify` threw a `NullReferenceException` that escaped as an unhandled 500.

Since a `Parameters` body without a `resource` is malformed caller input rather than a server fault, it now gets the same 400 + `OperationOutcome` that an empty body already gets, and logs a warning consistent with the other bad-request paths in this controller.

### Changes

- `FhirController.DeIdentify`: null-check the inner resource, return `BadRequest(BadRequestOutcome)`.
- `FhirControllerTests`: add `DeIdentify_WithParametersCarryingNoResource_ShouldReturnBadRequest`.

### Verification

The new test fails on `master` with the exact NRE from the issue:

```
Xunit.MicrosoftTestingPlatform.XunitException: System.NullReferenceException : Object reference not set to an instance of an object.
  at FhirPseudonymizer.Controllers.FhirController.DeIdentify(Resource resource) in src/FhirPseudonymizer/Controllers/FhirController.cs:119
```

and passes with the fix. Full suite: **155/155 passing**. CSharpier reports no formatting changes.
