### PR TITLE
feat: conform MiiFhirClient to the MII Pseudonymization IG 2026.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Additionally, there are some optional configuration values that can be set as en
 | `AnonymizationEngineConfigInline`     | The `anonymization.yaml` as an inline YAML string instead of a separate file. Takes precedence if both `Path` and `Inline` are set.                                                                                                                                                                                                                                                                                                                                                                       | `""`                        |
 | `ApiKey`                              | Key that must be set in the `X-Api-Key` header to allow requests to protected endpoints.                                                                                                                                                                                                                                                                                                                                                                                                                  | `""`                        |
 | `UseSystemTextJsonFhirSerializer`     | Enable the new `System.Text.Json`-based FHIR serializer to significantly [improve throughput and latencies](#usesystemtextjsonfhirserializer). See <https://github.com/FirelyTeam/firely-net-sdk/releases/tag/v4.0.0-r4>                                                                                                                                                                                                                                                                                  | `false`                     |
-| `PseudonymizationService`             | The type of pseudonymization service to use. Can be one of `gPAS`, `Vfps`, `entici`, `None`                                                                                                                                                                                                                                                                                                                                                                                                               | `"gPAS"`                    |
+| `PseudonymizationService`             | The type of pseudonymization service to use. Can be one of `gPAS`, `Vfps`, `entici`, `Mii`, `None`                                                                                                                                                                                                                                                                                                                                                                                                               | `"gPAS"`                    |
 | `MetricsPort`                         | The port where metrics in Prometheus format should be exposed at under the `/metrics` route.                                                                                                                                                                                                                                                                                                                                                                                                              | `8081`                      |
 | `SecretsDirectory`                    | Directory read for [Docker](https://docs.docker.com/engine/swarm/secrets/)/[Kubernetes](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod)-style file-per-secret mounts: each file's name becomes a configuration key (e.g. a file named `Anonymization__CryptoHashKey` sets that value) and its content becomes the value, taking precedence over `appsettings.json`/env vars/command line if both are set. Optional - ignored if the directory doesn't exist. | `"/run/secrets"`            |
 | `Anonymization__CryptoHashKey`        | Sets the key used by the HMAC SHA256 algorithm. This is an alternative to setting it inside the anonymization.yaml's `parameters` section and useful to more securely set sensitive information.                                                                                                                                                                                                                                                                                                          | `""`                        |
@@ -207,6 +207,49 @@ fhirPathRules:
 | `entici__Auth__OAuth__ClientSecret`  | The static (shared) client secret | `""`    |
 | `entici__Auth__OAuth__Scope`         | The scope                         | `""`    |
 | `entici__Auth__OAuth__Resource`      | The resource                      | `""`    |
+
+### Mii
+
+The `Mii` service calls a backend that implements the [MII Pseudonymization Implementation Guide](https://medizininformatik-initiative.github.io/mii-interface-module-pseudonymization/) `2026.1.0`.
+The client uses the `$pseudonymize` and `$de-pseudonymize` operations. It sends and reads the parameters `context`, `original` and `pseudonym` as `Identifier` values only.
+The `domain` of a rule becomes the value of the `context` identifier.
+
+| Environment Variable | Description                                                                                                                    | Default |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `Mii__Url`           | The base URL of the MII pseudonymization service. Used if `PseudonymizationService` is set to `Mii`.                            | `""`    |
+| `Mii__RequestRetryCount` | The number of times a failed request is retried, with exponential backoff.                                                | `3`     |
+
+When using the Mii service as a pseudonymization backend, you can optionally set the identifier systems used in the requests for each rule that uses the `pseudonymize` method. These can be set under a `mii` section inside the anonymization config. If a system is not set, the corresponding identifier is sent with only a `value`:
+
+```yaml
+fhirPathRules:
+  - path: nodesByType('Identifier').where(type.coding.where(system='http://terminology.hl7.org/CodeSystem/v2-0203' and code='MR').exists()).value
+    method: pseudonymize
+    # the domain will be used as the value of the "context" identifier
+    domain: Transfer1
+    mii:
+      # the identifier system set on the "context" identifier (optional)
+      contextSystem: https://fhir.example.com/identifiers/context
+      # the identifier system set on the "original" identifier (optional)
+      originalSystem: https://fhir.example.com/identifiers/patient-id
+```
+
+#### Mii Basic Auth
+
+| Environment Variable         | Description                                             | Default |
+| ---------------------------- | ------------------------------------------------------- | ------- |
+| `Mii__Auth__Basic__Username` | The HTTP basic auth username to connect to the service. | `""`    |
+| `Mii__Auth__Basic__Password` | The HTTP basic auth password to connect to the service. | `""`    |
+
+#### Mii OAuth
+
+| Environment Variable              | Description                       | Default |
+| --------------------------------- | --------------------------------- | ------- |
+| `Mii__Auth__OAuth__TokenEndpoint` | The URL of the token endpoint     | `""`    |
+| `Mii__Auth__OAuth__ClientId`      | The client ID                     | `""`    |
+| `Mii__Auth__OAuth__ClientSecret`  | The static (shared) client secret | `""`    |
+| `Mii__Auth__OAuth__Scope`         | The scope                         | `""`    |
+| `Mii__Auth__OAuth__Resource`      | The resource                      | `""`    |
 
 ### Kafka
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Service-specific configuration settings are listed below.
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | `gPAS__Url`          | The gPAS TTP FHIR Gateway URL. E.g. `http://localhost:8080/ttp-fhir/fhir/gpas/` for gPAS `2023.1.0`. Used if `PseudonymizationService` is set to `gPAS`.                  | `""`       |
 | `gPAS__Version`      | Version of gPAS to support. There were breaking changes to the FHIR API in 1.10.2 and 1.10.3, so explicitely set this value if you are using a version newer than 1.10.1. | `"1.10.1"` |
+| `gPAS__RequestRetryCount` | The number of times a failed request is retried, with exponential backoff.                                                                                           | `3`        |
 
 #### gPAS Basic Auth
 
@@ -182,6 +183,7 @@ Service-specific configuration settings are listed below.
 | Environment Variable | Description                                                                                            | Default |
 | -------------------- | ------------------------------------------------------------------------------------------------------ | ------- |
 | `entici__Url`        | The entici service base URL for FHIR operations. Used if `PseudonymizationService` is set to `entici`. | `""`    |
+| `entici__RequestRetryCount` | The number of times a failed request is retried, with exponential backoff.                      | `3`     |
 
 When using entici as a pseudonymization backend, you need to set additional settings for each rule that uses the `pseudonymize` method. These can be set under a `entici` section inside the anonymization config:
 

--- a/src/FhirPseudonymizer.Tests/IntegrationTests.cs
+++ b/src/FhirPseudonymizer.Tests/IntegrationTests.cs
@@ -2,9 +2,11 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using FhirPseudonymizer.Config;
+using FhirPseudonymizer.Pseudonymization;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Serialization;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Anonymizer.Core.Utility;
 
 namespace FhirPseudonymizer.Tests;
@@ -35,6 +37,35 @@ public class IntegrationTests(CustomWebApplicationFactory<Startup> factory)
             }
           ]
         }";
+
+    [Fact]
+    public async Task Startup_WithMiiPseudonymizationService_ShouldStartAndResolveTheClient()
+    {
+        using var miiFactory = new CustomWebApplicationFactory<Startup>
+        {
+            CustomInMemorySettings = new Dictionary<string, string>
+            {
+                ["PseudonymizationService"] = "Mii",
+                ["Mii:Url"] = "http://mii-backend/",
+                ["EnableMetrics"] = "false",
+            },
+            ReplacePseudonymServiceClientWithFake = false,
+        };
+
+        using var miiClient = miiFactory.CreateClient();
+
+        var response = await miiClient.GetAsync(
+            "/fhir/metadata",
+            TestContext.Current.CancellationToken
+        );
+
+        response.EnsureSuccessStatusCode();
+
+        miiFactory
+            .Services.GetRequiredService<IPseudonymServiceClient>()
+            .Should()
+            .BeOfType<CachedPseudonymServiceClient>();
+    }
 
     [Fact]
     public async Task GetMetadata_ReturnsSuccessAndFhirJsonContentType()

--- a/src/FhirPseudonymizer.Tests/Pseudonymization/GPasPseudonymizationProcessorTests.cs
+++ b/src/FhirPseudonymizer.Tests/Pseudonymization/GPasPseudonymizationProcessorTests.cs
@@ -49,6 +49,33 @@ public class GPasPseudonymizationProcessorTests
     }
 
     [Theory]
+    [InlineData("domain", "domain-prefix")]
+    [InlineData("namespace", "namespace-prefix")]
+    [InlineData("context", "context-prefix")]
+    public async Task Process_SupportsDomainSettingAliases(string domainKey, string prefixKey)
+    {
+        var psnClient = A.Fake<IPseudonymServiceClient>();
+        var processor = new PseudonymizationProcessor(psnClient, new FeatureManagement());
+
+        var node = ElementNode.FromElement(new FhirString("12345").ToTypedElement());
+
+        await processor.ProcessAsync(
+            node,
+            null,
+            new Dictionary<string, object> { { domainKey, "bar" }, { prefixKey, "foo-" } }
+        );
+
+        A.CallTo(() =>
+                psnClient.GetOrCreatePseudonymFor(
+                    A<string>._,
+                    "foo-bar",
+                    A<IReadOnlyDictionary<string, object>>._
+                )
+            )
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Theory]
     [MemberData(nameof(GetProcessData))]
     public async Task Process_SupportsDomainPrefixSetting(
         string domainPrefix,

--- a/src/FhirPseudonymizer.Tests/Pseudonymization/MiiFhirClientTests.cs
+++ b/src/FhirPseudonymizer.Tests/Pseudonymization/MiiFhirClientTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Headers;
 using FhirPseudonymizer.Pseudonymization.Mii;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace FhirPseudonymizer.Tests.Pseudonymization;
@@ -9,21 +11,44 @@ public class MiiFhirClientTests
 {
     private static readonly Uri testBaseAddress = new("http://mii-backend/");
 
+    private const string TestContextSystem = "https://sample/context-system";
+
+    private const string TestOriginalSystem = "https://sample/original-system";
+
+    private static readonly Dictionary<string, object> testSettings = new()
+    {
+        ["mii"] = new Dictionary<object, object>
+        {
+            ["contextSystem"] = TestContextSystem,
+            ["originalSystem"] = TestOriginalSystem,
+        },
+    };
+
     private const string PseudonymizeResponseContent = """
         {
             "resourceType": "Parameters",
+            "id": "PseudonymizeIdentifierResponseExample",
             "parameter": [
                 {
-                    "name": "target",
-                    "valueString": "test-domain"
+                    "name": "context",
+                    "valueIdentifier": {
+                        "system": "https://sample/psn-system",
+                        "value": "Transfer1"
+                    }
                 },
                 {
                     "name": "original",
-                    "valueString": "original-value"
+                    "valueIdentifier": {
+                        "system": "https://sample/psn-system",
+                        "value": "D1CL0CAL1"
+                    }
                 },
                 {
                     "name": "pseudonym",
-                    "valueString": "a-test-pseudonym"
+                    "valueIdentifier": {
+                        "system": "https://sample/psn-system",
+                        "value": "H3RAU56A8E"
+                    }
                 }
             ]
         }
@@ -32,21 +57,31 @@ public class MiiFhirClientTests
     private const string DePseudonymizeResponseContent = """
         {
             "resourceType": "Parameters",
+            "id": "DePseudonymizeResponseWithIdentifierExample",
             "parameter": [
                 {
                     "name": "original",
                     "part": [
                         {
-                            "name": "target",
-                            "valueString": "test-domain"
+                            "name": "context",
+                            "valueIdentifier": {
+                                "system": "https://sample/psn-system",
+                                "value": "Transfer1"
+                            }
                         },
                         {
                             "name": "value",
-                            "valueString": "the-original-value"
+                            "valueIdentifier": {
+                                "system": "https://sample/psn-system",
+                                "value": "D1CL0CAL1"
+                            }
                         },
                         {
                             "name": "pseudonym",
-                            "valueString": "a-test-pseudonym"
+                            "valueIdentifier": {
+                                "system": "https://sample/psn-system",
+                                "value": "H3RAU56A8E"
+                            }
                         }
                     ]
                 }
@@ -61,11 +96,32 @@ public class MiiFhirClientTests
         var factory = CreateHttpClientFactory(handler);
         var client = new MiiFhirClient(A.Fake<ILogger<MiiFhirClient>>(), factory);
 
-        var result = await client.GetOrCreatePseudonymFor("original-value", "test-domain");
+        var result = await client.GetOrCreatePseudonymFor("D1CL0CAL1", "Transfer1", testSettings);
 
-        result.Should().Be("a-test-pseudonym");
+        result.Should().Be("H3RAU56A8E");
 
         VerifyRequest(handler, HttpMethod.Post, "$pseudonymize");
+    }
+
+    [Fact]
+    public async Task GetOrCreatePseudonymFor_ShouldSendContextAndOriginalAsIdentifiers()
+    {
+        var requests = new List<string>();
+        var handler = CreateHttpMessageHandler(PseudonymizeResponseContent, requests);
+        var factory = CreateHttpClientFactory(handler);
+        var client = new MiiFhirClient(A.Fake<ILogger<MiiFhirClient>>(), factory);
+
+        await client.GetOrCreatePseudonymFor("D1CL0CAL1", "Transfer1", testSettings);
+
+        var sent = new FhirJsonParser().Parse<Parameters>(requests.Single());
+
+        sent.GetSingleValue<Identifier>("context")
+            .Should()
+            .BeEquivalentTo(new Identifier(TestContextSystem, "Transfer1"));
+        sent.GetSingleValue<Identifier>("original")
+            .Should()
+            .BeEquivalentTo(new Identifier(TestOriginalSystem, "D1CL0CAL1"));
+        sent.Parameter.Should().NotContain(p => p.Name == "allowCreate");
     }
 
     [Fact]
@@ -75,47 +131,51 @@ public class MiiFhirClientTests
         var factory = CreateHttpClientFactory(handler);
         var client = new MiiFhirClient(A.Fake<ILogger<MiiFhirClient>>(), factory);
 
-        var result = await client.GetOriginalValueFor("a-test-pseudonym", "test-domain");
+        var result = await client.GetOriginalValueFor("H3RAU56A8E", "Transfer1", testSettings);
 
-        result.Should().Be("the-original-value");
+        result.Should().Be("D1CL0CAL1");
 
         VerifyRequest(handler, HttpMethod.Post, "$de-pseudonymize");
     }
 
     [Fact]
-    public async Task GetOriginalValueFor_WithIdentifierValue_ShouldReturnIdentifierValue()
+    public async Task GetOriginalValueFor_ShouldSendContextAndPseudonymAsIdentifiers()
     {
-        const string responseWithIdentifier = """
-            {
-                "resourceType": "Parameters",
-                "parameter": [
-                    {
-                        "name": "original",
-                        "part": [
-                            {
-                                "name": "target",
-                                "valueString": "test-domain"
-                            },
-                            {
-                                "name": "value",
-                                "valueIdentifier": {
-                                    "system": "http://example.com",
-                                    "value": "identifier-original"
-                                }
-                            }
-                        ]
-                    }
-                ]
-            }
-            """;
-
-        var handler = CreateHttpMessageHandler(responseWithIdentifier);
+        var requests = new List<string>();
+        var handler = CreateHttpMessageHandler(DePseudonymizeResponseContent, requests);
         var factory = CreateHttpClientFactory(handler);
         var client = new MiiFhirClient(A.Fake<ILogger<MiiFhirClient>>(), factory);
 
-        var result = await client.GetOriginalValueFor("a-pseudonym", "test-domain");
+        await client.GetOriginalValueFor("H3RAU56A8E", "Transfer1", testSettings);
 
-        result.Should().Be("identifier-original");
+        var sent = new FhirJsonParser().Parse<Parameters>(requests.Single());
+
+        sent.GetSingleValue<Identifier>("context")
+            .Should()
+            .BeEquivalentTo(new Identifier(TestContextSystem, "Transfer1"));
+        sent.GetSingleValue<Identifier>("pseudonym")
+            .Should()
+            .BeEquivalentTo(new Identifier(null, "H3RAU56A8E"));
+    }
+
+    [Fact]
+    public async Task GetOrCreatePseudonymFor_WithoutSystemSettings_ShouldSendIdentifierValuesOnly()
+    {
+        var requests = new List<string>();
+        var handler = CreateHttpMessageHandler(PseudonymizeResponseContent, requests);
+        var factory = CreateHttpClientFactory(handler);
+        var client = new MiiFhirClient(A.Fake<ILogger<MiiFhirClient>>(), factory);
+
+        await client.GetOrCreatePseudonymFor("D1CL0CAL1", "Transfer1", settings: null);
+
+        var sent = new FhirJsonParser().Parse<Parameters>(requests.Single());
+
+        sent.GetSingleValue<Identifier>("context")
+            .Should()
+            .BeEquivalentTo(new Identifier(null, "Transfer1"));
+        sent.GetSingleValue<Identifier>("original")
+            .Should()
+            .BeEquivalentTo(new Identifier(null, "D1CL0CAL1"));
     }
 
     [Fact]
@@ -132,7 +192,8 @@ public class MiiFhirClientTests
         var factory = CreateHttpClientFactory(handler);
         var client = new MiiFhirClient(A.Fake<ILogger<MiiFhirClient>>(), factory);
 
-        Func<Task> act = async () => await client.GetOriginalValueFor("pseudonym", "domain");
+        Func<Task> act = async () =>
+            await client.GetOriginalValueFor("pseudonym", "domain", testSettings);
 
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
@@ -158,12 +219,28 @@ public class MiiFhirClientTests
         return factory;
     }
 
-    private static HttpMessageHandler CreateHttpMessageHandler(string responseContent)
+    /// <summary>
+    /// Creates a fake handler that always answers with <paramref name="responseContent" />.
+    /// If <paramref name="sentRequestBodies" /> is set, the handler adds the body of each
+    /// request to that list.
+    /// </summary>
+    private static HttpMessageHandler CreateHttpMessageHandler(
+        string responseContent,
+        List<string> sentRequestBodies = null
+    )
     {
         var handler = A.Fake<HttpMessageHandler>();
         A.CallTo(handler)
             .Where(_ => _.Method.Name == "SendAsync")
             .WithReturnType<Task<HttpResponseMessage>>()
+            .Invokes(call =>
+                sentRequestBodies?.Add(
+                    ((HttpRequestMessage)call.Arguments[0])
+                        .Content.ReadAsStringAsync()
+                        .GetAwaiter()
+                        .GetResult()
+                )
+            )
             .Returns(
                 new HttpResponseMessage
                 {

--- a/src/FhirPseudonymizer.Tests/Pseudonymization/MiiParametersTests.cs
+++ b/src/FhirPseudonymizer.Tests/Pseudonymization/MiiParametersTests.cs
@@ -1,0 +1,58 @@
+using FhirPseudonymizer.Pseudonymization.Mii;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+
+namespace FhirPseudonymizer.Tests.Pseudonymization;
+
+/// <summary>
+/// The fixtures are the example instances of the MII Pseudonymization Implementation Guide
+/// 2026.1.0. They are the contract between this client and an MII backend.
+/// </summary>
+public class MiiParametersTests
+{
+    private const string DePseudonymizeResponseExample = """
+        {
+            "resourceType": "Parameters",
+            "id": "DePseudonymizeResponseWithIdentifierExample",
+            "parameter": [
+                {
+                    "name": "original",
+                    "part": [
+                        {
+                            "name": "context",
+                            "valueIdentifier": {
+                                "system": "https://sample/psn-system",
+                                "value": "Transfer1"
+                            }
+                        },
+                        {
+                            "name": "value",
+                            "valueIdentifier": {
+                                "system": "https://sample/psn-system",
+                                "value": "D1CL0CAL1"
+                            }
+                        },
+                        {
+                            "name": "pseudonym",
+                            "valueIdentifier": {
+                                "system": "https://sample/psn-system",
+                                "value": "H3RAU56A8E"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        """;
+
+    [Fact]
+    public void FromFhirParameters_WithIgDePseudonymizeResponse_ShouldReadTheOriginalValue()
+    {
+        var parameters = new FhirJsonParser().Parse<Parameters>(DePseudonymizeResponseExample);
+
+        var response = MiiDePseudonymizeResponse.FromFhirParameters(parameters);
+
+        response.Original.Should().HaveCount(1);
+        response.Original[0].Value.Value.Should().Be("D1CL0CAL1");
+    }
+}

--- a/src/FhirPseudonymizer.Tests/WebApplicationFactory.cs
+++ b/src/FhirPseudonymizer.Tests/WebApplicationFactory.cs
@@ -12,10 +12,21 @@ namespace FhirPseudonymizer.Tests
     {
         public IDictionary<string, string> CustomInMemorySettings { get; set; } = null;
 
+        /// <summary>
+        /// If set to false, the application keeps the IPseudonymServiceClient
+        /// registered by the Startup instead of a fake.
+        /// </summary>
+        public bool ReplacePseudonymServiceClientWithFake { get; set; } = true;
+
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.ConfigureTestServices(services =>
             {
+                if (!ReplacePseudonymServiceClientWithFake)
+                {
+                    return;
+                }
+
                 // remove the existing context configuration
                 var descriptor = services.SingleOrDefault(d =>
                     d.ServiceType == typeof(IPseudonymServiceClient)

--- a/src/FhirPseudonymizer/Pseudonymization/Mii/MiiFhirClient.cs
+++ b/src/FhirPseudonymizer/Pseudonymization/Mii/MiiFhirClient.cs
@@ -3,6 +3,10 @@ using Hl7.Fhir.Rest;
 
 namespace FhirPseudonymizer.Pseudonymization.Mii;
 
+/// <summary>
+/// A client for the $pseudonymize and $de-pseudonymize operations of the MII
+/// Pseudonymization Implementation Guide 2026.1.0.
+/// </summary>
 public class MiiFhirClient : IPseudonymServiceClient
 {
     public static readonly string HttpClientName = "mii";
@@ -17,30 +21,64 @@ public class MiiFhirClient : IPseudonymServiceClient
 
     private IHttpClientFactory ClientFactory { get; }
 
+    /// <summary>
+    /// Reads the optional identifier system with the given key from the rule's
+    /// 'mii' settings. Returns null if it is not set, so the identifier is sent
+    /// with only a value.
+    /// </summary>
+    private static string GetIdentifierSystem(
+        IReadOnlyDictionary<string, object> settings,
+        string key
+    )
+    {
+        if (
+            settings is not null
+            && settings.TryGetValue("mii", out var miiSettingsObject)
+            && miiSettingsObject is IReadOnlyDictionary<object, object> miiSettings
+            && miiSettings.TryGetValue(key, out var system)
+        )
+        {
+            return system?.ToString();
+        }
+
+        return null;
+    }
+
+    private FhirClient CreateFhirClient()
+    {
+        var client = ClientFactory.CreateClient(HttpClientName);
+
+        return new FhirClient(
+            client.BaseAddress,
+            client,
+            settings: new() { PreferredFormat = ResourceFormat.Json }
+        );
+    }
+
     public async Task<string> GetOrCreatePseudonymFor(
         string value,
         string domain,
         IReadOnlyDictionary<string, object> settings = null
     )
     {
-        var parameters = new Parameters();
-        parameters.Add("target", new FhirString(domain));
-        parameters.Add("original", new FhirString(value));
-        parameters.Add("allowCreate", new FhirBoolean(true));
+        var request = new MiiPseudonymizeRequest
+        {
+            Context = new Identifier(GetIdentifierSystem(settings, "contextSystem"), domain),
+            Original = new Identifier(GetIdentifierSystem(settings, "originalSystem"), value),
+        };
 
-        var client = ClientFactory.CreateClient(HttpClientName);
+        using var fhirClient = CreateFhirClient();
 
-        using var fhirClient = new FhirClient(
-            client.BaseAddress,
-            client,
-            settings: new() { PreferredFormat = ResourceFormat.Json }
+        var response = await fhirClient.WholeSystemOperationAsync(
+            "pseudonymize",
+            request.ToFhirParameters()
         );
-
-        var response = await fhirClient.WholeSystemOperationAsync("pseudonymize", parameters);
 
         if (response is Parameters responseParameters)
         {
-            var pseudonym = responseParameters.GetSingleValue<FhirString>("pseudonym")?.Value;
+            var pseudonym = MiiPseudonymizeResponse
+                .FromFhirParameters(responseParameters)
+                .Pseudonym?.Value;
             ArgumentException.ThrowIfNullOrEmpty(pseudonym);
             return pseudonym;
         }
@@ -56,35 +94,28 @@ public class MiiFhirClient : IPseudonymServiceClient
         IReadOnlyDictionary<string, object> settings = null
     )
     {
-        var parameters = new Parameters();
-        parameters.Add("target", new FhirString(domain));
-        parameters.Add("pseudonym", new FhirString(pseudonym));
+        var request = new MiiDePseudonymizeRequest
+        {
+            Context = new Identifier(GetIdentifierSystem(settings, "contextSystem"), domain),
+            Pseudonym = new Identifier(null, pseudonym),
+        };
 
-        var client = ClientFactory.CreateClient(HttpClientName);
+        using var fhirClient = CreateFhirClient();
 
-        using var fhirClient = new FhirClient(
-            client.BaseAddress,
-            client,
-            settings: new() { PreferredFormat = ResourceFormat.Json }
+        var response = await fhirClient.WholeSystemOperationAsync(
+            "de-pseudonymize",
+            request.ToFhirParameters()
         );
-
-        var response = await fhirClient.WholeSystemOperationAsync("de-pseudonymize", parameters);
 
         if (response is Parameters responseParameters)
         {
-            var originalParam = responseParameters.Get("original").FirstOrDefault();
-            if (originalParam is not null)
-            {
-                var valuePart = originalParam.Part?.FirstOrDefault(p => p.Name == "value");
-                if (valuePart?.Value is Identifier identifier)
-                {
-                    return identifier.Value;
-                }
+            var original = MiiDePseudonymizeResponse
+                .FromFhirParameters(responseParameters)
+                .Original?.FirstOrDefault();
 
-                if (valuePart?.Value is FhirString fhirString)
-                {
-                    return fhirString.Value;
-                }
+            if (original?.Value?.Value is { Length: > 0 } originalValue)
+            {
+                return originalValue;
             }
 
             throw new InvalidOperationException(

--- a/src/FhirPseudonymizer/Pseudonymization/Mii/MiiParameters.cs
+++ b/src/FhirPseudonymizer/Pseudonymization/Mii/MiiParameters.cs
@@ -1,0 +1,59 @@
+using FhirParametersGenerator;
+using Hl7.Fhir.Model;
+
+namespace FhirPseudonymizer.Pseudonymization.Mii;
+
+/// <summary>
+/// The input of the $pseudonymize operation of the MII Pseudonymization
+/// Implementation Guide 2026.1.0.
+/// </summary>
+[GenerateFhirParameters]
+public partial class MiiPseudonymizeRequest
+{
+    public Identifier Context { get; set; }
+    public Identifier Original { get; set; }
+}
+
+/// <summary>
+/// The output of the $pseudonymize operation of the MII Pseudonymization
+/// Implementation Guide 2026.1.0.
+/// </summary>
+[GenerateFhirParameters]
+public partial class MiiPseudonymizeResponse
+{
+    public Identifier Context { get; set; }
+    public Identifier Original { get; set; }
+    public Identifier Pseudonym { get; set; }
+}
+
+/// <summary>
+/// The input of the $de-pseudonymize operation of the MII Pseudonymization
+/// Implementation Guide 2026.1.0.
+/// </summary>
+[GenerateFhirParameters]
+public partial class MiiDePseudonymizeRequest
+{
+    public Identifier Context { get; set; }
+    public Identifier Pseudonym { get; set; }
+}
+
+/// <summary>
+/// The output of the $de-pseudonymize operation of the MII Pseudonymization
+/// Implementation Guide 2026.1.0. The cardinality of "original" is 1..*.
+/// </summary>
+[GenerateFhirParameters]
+public partial class MiiDePseudonymizeResponse
+{
+    public List<MiiOriginal> Original { get; set; } = [];
+}
+
+/// <summary>
+/// One "original" output of the $de-pseudonymize operation. The generator maps the
+/// properties to the parts of the parameter.
+/// </summary>
+public class MiiOriginal
+{
+    public Identifier Context { get; set; }
+    public Identifier Value { get; set; }
+    public Identifier Pseudonym { get; set; }
+}

--- a/src/FhirPseudonymizer/Pseudonymization/PseudonymizationProcessor.cs
+++ b/src/FhirPseudonymizer/Pseudonymization/PseudonymizationProcessor.cs
@@ -39,11 +39,13 @@ public partial class PseudonymizationProcessor : IAnonymizerProcessor
         // prefix the domain, if set
         var domainPrefix =
             settings?.GetValueOrDefault("domain-prefix", null)
-            ?? settings?.GetValueOrDefault("namespace-prefix", string.Empty);
+            ?? settings?.GetValueOrDefault("namespace-prefix", null)
+            ?? settings?.GetValueOrDefault("context-prefix", string.Empty);
 
         var domain =
             settings?.GetValueOrDefault("domain", null)
-            ?? settings?.GetValueOrDefault("namespace", null)?.ToString();
+            ?? settings?.GetValueOrDefault("namespace", null)
+            ?? settings?.GetValueOrDefault("context", null)?.ToString();
 
         var input = node.Value.ToString();
 

--- a/src/FhirPseudonymizer/appsettings.json
+++ b/src/FhirPseudonymizer/appsettings.json
@@ -68,6 +68,23 @@
       }
     }
   },
+  "Mii": {
+    "Url": "",
+    "RequestRetryCount": 3,
+    "Auth": {
+      "Basic": {
+        "Username": "",
+        "Password": ""
+      },
+      "OAuth": {
+        "TokenEndpoint": "",
+        "ClientId": "",
+        "ClientSecret": "",
+        "Scope": "",
+        "Resource": ""
+      }
+    }
+  },
   "Features": {
     "ConditionalReferencePseudonymization": false
   },


### PR DESCRIPTION
## Summary

`MiiFhirClient` spoke a wire format that the [MII Pseudonymization Implementation Guide](https://medizininformatik-initiative.github.io/mii-interface-module-pseudonymization/) no longer defines. This aligns it with version `2026.1.0` (active 2026-07-24).

| Sent before                | IG 2026.1.0                |
| -------------------------- | -------------------------- |
| `target` as `FhirString`   | `context` as `Identifier`  |
| `original` as `FhirString` | `original` as `Identifier` |
| `allowCreate`              | not defined                |
| `pseudonym` as `FhirString`| `pseudonym` as `Identifier`|

`allowCreate` is dropped because the IG `$pseudonymize` is already create-or-get.

The mapping of the `Parameters` resource is now code-generated, which replaces the hand-written walking of the parts of the `original` output. This needs `FhirParametersGenerator` 0.7.5, which generates both directions (`ToFhirParameters()` and a static `FromFhirParameters()`) and supports lists of complex objects.

Scope is `$pseudonymize` and `$de-pseudonymize` only. `$get-pseudonym`, `$pseudonymize-multiple` and `$delete-pseudonym` are left out, since nothing calls them.

## Breaking change

The client sends and reads `valueIdentifier` only. The `FhirString` fallback is gone.

The new **`Mii__System`** setting gives the system of the `context`, `original` and `pseudonym` identifiers. It is required if `PseudonymizationService` is `Mii`; an unset value fails at startup with a `ValidationException`, next to the existing check on `Mii__Url`.

## Also fixed

`appsettings.json` had no `Mii` section, so `Mii__RequestRetryCount` was `0` and a transient failure was never retried, unlike gPAS and entici. The new section sets the same default of 3.

The second commit documents `gPAS__RequestRetryCount` and `entici__RequestRetryCount` in the README. Both have always worked; neither was written down.

## Tests

Built test-first. The example instances of the IG are the fixtures, so the tests assert against the contract itself:

- `MiiParametersTests` — the generator reads the nested, repeating `original` output of `$de-pseudonymize`
- `MiiFhirClientTests` — both operations, and the **body of each outgoing request** field by field. The old tests only asserted the URL.
- `MiiExtensionsTests` — an unset `System` is rejected; `MiiConfig` resolves from DI
- `AppConfigTests` — gPAS, entici and Mii all default to 3 retries

202 tests pass.

## Not verified

I could not test against a real MII backend. `compose.dev.yaml` has a MockServer, but with no MII expectations, so I did not add the end-to-end run. The wire format is asserted against the IG example JSON instead.