### PR TITLE
fix: wire AnonymizerLogging to the app's configured ILoggerFactory

### DIFF
--- a/src/FhirPseudonymizer/Microsoft.Health.Fhir.Anonymizer.Shared.Core/AnonymizerLogging.cs
+++ b/src/FhirPseudonymizer/Microsoft.Health.Fhir.Anonymizer.Shared.Core/AnonymizerLogging.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace Microsoft.Health.Fhir.Anonymizer.Core
 {
     public static class AnonymizerLogging
@@ -6,7 +8,14 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core
 
         public static ILogger CreateLogger<T>()
         {
-            return LoggerFactory.CreateLogger<T>();
+            try
+            {
+                return LoggerFactory.CreateLogger<T>();
+            }
+            catch (ObjectDisposedException)
+            {
+                return NullLogger<T>.Instance;
+            }
         }
     }
 }

--- a/src/FhirPseudonymizer/Startup.cs
+++ b/src/FhirPseudonymizer/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Health.Fhir.Anonymizer.Core;
 using Microsoft.OpenApi;
 using Prometheus;
 
@@ -180,8 +181,13 @@ public class Startup
         }
     }
 
-    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
     {
+        // The anonymization engine (AnonymizerEngine, AnonymizationVisitor, CryptoHashProcessor, etc.)
+        // creates its loggers via AnonymizerLogging instead of using DI, so without this it never
+        // picks up the app's configured logging providers/levels and silently discards all log output.
+        AnonymizerLogging.LoggerFactory = loggerFactory;
+
         if (env.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();


### PR DESCRIPTION
AnonymizerEngine, AnonymizationVisitor, CryptoHashProcessor and other engine-internal classes create their loggers via the static AnonymizerLogging.CreateLogger<T>(), which defaulted to a bare LoggerFactory() with no providers attached. Since nothing ever set AnonymizerLogging.LoggerFactory to the app's real, DI-configured factory, Logging__LogLevel__Default/appsettings logging config had no effect inside the anonymization engine, and all its debug/trace log output (e.g. per-node hash logging in CryptoHashProcessor) was silently discarded.